### PR TITLE
🔀 :: (#125) 로그인 에러처리 및 고도화

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -19,6 +19,7 @@ android {
 
 dependencies {
     implementation(project(":common:extension"))
+    implementation(project(":core:domain"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/core/data/src/main/java/com/idiotfrogs/data/LoginManager.kt
+++ b/core/data/src/main/java/com/idiotfrogs/data/LoginManager.kt
@@ -2,15 +2,22 @@ package com.idiotfrogs.data
 
 import android.content.Context
 import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseAuthWebException
 import com.google.firebase.auth.OAuthProvider
+import com.idiotfrogs.domain.exception.LoginCancelledException
 import com.idiotfrogs.extension.findActivity
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
+import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 @ActivityScoped
 class LoginManager @Inject constructor(
@@ -34,66 +41,74 @@ class LoginManager @Inject constructor(
             context = context
         )
 
-        val credentialData = response.credential.data
-        // TODO: googleIdTokenCredential 사용처에 맞게 처리
-        val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credentialData)
-
-        /**
-         * ex)
-         * googleIdTokenCredential.idToken -> backend단에 넘겨줄 idToken 값
-         *
-         * googleIdTokenCredential.profilePictureUri,
-         * googleIdTokenCredential.phoneNumber,
-         * etc..
-         * -> googleIdTokenCredential로 얻어올 수 있는 값
-         *
-         * feature단에 token을 직접 넘겨주지 말아야 함
-         * -> Oauth 관련 로직을 모두 LoginManager에 위임하기 위함
-         * -> 관심사 분리, Oauth 세부 로직은 LoginManager에서만 처리
-         */
+        when (val credential = response.credential) {
+            is CustomCredential -> {
+                if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                    try {
+                        val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
+                        // TODO: idToken 관련 처리
+                    } catch (exception: Exception) {
+                        throw exception
+                    }
+                } else {
+                    throw Exception("Unexpected type of credential")
+                }
+            }
+            else -> {
+                throw Exception("Unexpected type of credential")
+            }
+        }
     }
 
-    fun appleLogin() {
-        val provider = OAuthProvider.newBuilder("apple.com")
+    suspend fun appleLogin() = suspendCancellableCoroutine { continuation ->
         // TODO: 필요한 기본 값 범위를 넘는 OAuth 2.0 범위 추가 지정 (필요한 경우)
         // TODO: 로그인 화면 언어를 추가로 설정해줘야 하는 경우 locale 설정
+        val provider = OAuthProvider.newBuilder("apple.com")
         val auth = FirebaseAuth.getInstance()
         val pending = auth.pendingAuthResult
 
         // 대기 중인 결과가 존재하는 경우
         if (pending != null) {
             pending.addOnSuccessListener { authResult ->
-                // TODO: authResult 사용처에 맞게 처리
-                authResult.user
-
-                /**
-                 * ex)
-                 * authResult.user?.getIdToken(false)?.result?.token -> backend단에 넘겨줄 idToken 값
-                 *
-                 * authResult.user?.photoUrl
-                 * authResult.user?.phoneNumber,
-                 * etc..
-                 * -> authResult.getUser()를 통해 얻어올 수 있는 값
-                 *
-                 * feature단에 token을 직접 넘겨주지 말아야 함
-                 * -> Oauth 관련 로직을 모두 LoginManager에 위임하기 위함
-                 * -> 관심사 분리, Oauth 세부 로직은 LoginManager에서만 처리
-                 */
+                authResult.uidAction()
+                continuation.resume(Unit)
             }.addOnFailureListener { exception ->
-                throw exception
+                if (exception is FirebaseAuthWebException) {
+                    continuation.resumeWithException(LoginCancelledException())
+                } else {
+                    continuation.resumeWithException(exception)
+                }
             }
         } else {
             context.findActivity()?.let {
                 auth.startActivityForSignInWithProvider(it, provider.build())
                     .addOnSuccessListener { authResult ->
-                        // 위 addOnSuccessListener와 동일하게 처리
+                        authResult.uidAction()
+                        continuation.resume(Unit)
                     }
                     .addOnFailureListener { exception ->
-                        throw exception
+                        if (exception is FirebaseAuthWebException) {
+                            continuation.resumeWithException(LoginCancelledException())
+                        } else {
+                            continuation.resumeWithException(exception)
+                        }
                     }
             } ?: run {
-                throw Exception("activity is not available")
+                throw Exception("Activity is not available")
             }
+        }
+    }
+
+    private fun AuthResult.uidAction() {
+        this.user?.providerData?.takeIf { it.isNotEmpty() }?.let { providerData ->
+            providerData.forEach { userInfo ->
+                if (userInfo.providerId == "apple.com") {
+                    // TODO: uid 관련 처리
+                    return@let
+                }
+            }
+        } ?: run {
+            throw Exception("User or ProviderData is null")
         }
     }
 }

--- a/core/data/src/main/java/com/idiotfrogs/data/LoginManager.kt
+++ b/core/data/src/main/java/com/idiotfrogs/data/LoginManager.kt
@@ -70,7 +70,7 @@ class LoginManager @Inject constructor(
         // 대기 중인 결과가 존재하는 경우
         if (pending != null) {
             pending.addOnSuccessListener { authResult ->
-                authResult.uidAction()
+                authResult.sendUid()
                 continuation.resume(Unit)
             }.addOnFailureListener { exception ->
                 if (exception is FirebaseAuthWebException) {
@@ -83,7 +83,7 @@ class LoginManager @Inject constructor(
             context.findActivity()?.let {
                 auth.startActivityForSignInWithProvider(it, provider.build())
                     .addOnSuccessListener { authResult ->
-                        authResult.uidAction()
+                        authResult.sendUid()
                         continuation.resume(Unit)
                     }
                     .addOnFailureListener { exception ->
@@ -99,7 +99,7 @@ class LoginManager @Inject constructor(
         }
     }
 
-    private fun AuthResult.uidAction() {
+    private fun AuthResult.sendUid() {
         this.user?.providerData?.takeIf { it.isNotEmpty() }?.let { providerData ->
             providerData.forEach { userInfo ->
                 if (userInfo.providerId == "apple.com") {

--- a/core/domain/src/main/java/com/idiotfrogs/domain/exception/LoginCancelledException.kt
+++ b/core/domain/src/main/java/com/idiotfrogs/domain/exception/LoginCancelledException.kt
@@ -1,0 +1,3 @@
+package com.idiotfrogs.domain.exception
+
+class LoginCancelledException: Exception("User cancelled login")

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -8,6 +8,7 @@ android {
 
 dependencies {
     implementation(project(":core:data"))
+    implementation(project(":core:domain"))
 
     implementation(libs.androidx.navigation)
     implementation(libs.androidx.core.ktx)

--- a/feature/auth/src/main/java/com/idiotfrogs/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/idiotfrogs/auth/login/LoginViewModel.kt
@@ -2,6 +2,7 @@ package com.idiotfrogs.auth.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.idiotfrogs.domain.exception.LoginCancelledException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,7 +28,9 @@ class LoginViewModel @Inject constructor(): ViewModel() {
 
     // TODO: 공통 error 처리 CEH 분리
     private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        _uiState.value = LoginUiState.Error(throwable.message)
+        if (throwable !is LoginCancelledException) {
+            _uiState.value = LoginUiState.Error(throwable.message)
+        }
     }
 
     private val safeScope = viewModelScope + coroutineExceptionHandler


### PR DESCRIPTION
### 💡 개요
- 기존 로그인 에러 처리를 세분화 및 로그인 코드를 고도화

### 📃 작업 내용
- 분기에 따른 예외 처리 코드 추가
- appleLogin에 suspendCancellableCoroutine을 사용

### 🎸 기타
- LoginCancelledException의 경우 CEH에서 UiState를 Error로 처리하지 않도록 작업했는데 해당 부분 피드백 필요합니다.