### PR TITLE
🔀 :: (#148) TextField border 조건 iOS와 통일

### DIFF
--- a/core/designsystem/src/main/java/com/idiotfrogs/designsystem/component/MSTextField.kt
+++ b/core/designsystem/src/main/java/com/idiotfrogs/designsystem/component/MSTextField.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import com.idiotfrogs.designsystem.theme.MSTheme
+import com.idiotfrogs.designsystem.util.rememberKeyboardVisibility
 import com.idiotfrogs.designsystem.util.toSp
 import com.idiotfrogs.resource.pretendard
 
@@ -58,6 +59,7 @@ fun MSTextField(
     outputTransformation: OutputTransformation? = null,
     scrollState: ScrollState = rememberScrollState()
 ) {
+    val isShowKeyboard = rememberKeyboardVisibility()
     BasicTextField(
         state = textFieldState,
         modifier = modifier,
@@ -79,8 +81,7 @@ fun MSTextField(
                     .border(
                         width = 1.dp,
                         color = when {
-                            enabled && textFieldState.text.isEmpty() -> MSTheme.color.greyG2
-                            !enabled -> MSTheme.color.greyG2
+                            (enabled && !isShowKeyboard) || !enabled -> MSTheme.color.greyG2
                             else -> MSTheme.color.greyG5
                         },
                         shape = RoundedCornerShape(12.dp)


### PR DESCRIPTION
### 💡 개요
- TextField border 조건 iOS와 통일

### 📃 작업 내용
- 텍스트 입력 된 경우 border 처리에서 키보드 출력 시 border 처리로 변경

### 💻 구현 화면
https://github.com/user-attachments/assets/0902a098-a338-4fa3-8c4f-087a0a0ca7c9

