### PR TITLE
🔀 :: (#197) CI 병렬 처리 도입

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,7 +58,7 @@ jobs:
       - run: chmod +x gradlew
       - run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
       - run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ${{ github.workspace }}/app/google-services.json
-      - run: ./gradlew assembleDebug --stacktrace
+      - run: ./gradlew build
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,21 +58,21 @@ jobs:
       if: ${{ success() }}
       with:
         title: ✅ MemorySeal-Android-CI 성공! ✅
-        webhook: ${{ secrets.CODIN_DISCORD_WEBHOOK }}
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
         status: ${{ job.status }}
         image: ${{ secrets.SUCCESS_IMAGE }}
         color: 00FF00
         url: "https://github.com/sarisia/actions-status-discord"
-        username: Codin CI Bot
+        username: MemorySeal CI Bot
 
-    - name: Codin Android CI Discord Notification
+    - name: MemorySeal Android CI Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ failure() }}
       with:
-        title: ❗️ Codin-Android-CI 실패! ❗️
-        webhook: ${{ secrets.CODIN_DISCORD_WEBHOOK }}
+        title: ❗️ MemorySeal-Android-CI 실패! ❗️
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
         status: ${{ job.status }}
         image: ${{ secrets.FAILED_IMAGE }}
         color: 00FF00
         url: "https://github.com/sarisia/actions-status-discord"
-        username: Codin CI Bot
+        username: MemorySeal CI Bot

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,78 +1,90 @@
 name: Android CI
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx2g -Dorg.gradle.daemon=false"
+
 on:
   push:
     branches: [ "master", "develop" ]
   pull_request:
     branches: [ "master", "develop" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-
+  ktlint:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: gradle
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+      - run: chmod +x gradlew
+      - run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
+      - run: ./gradlew ktlintCheck
 
-    - name: Cache Gradle Packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{runner.os}}-gradle-${{hashFiles('**/*.gradle*', '**/gradle-wrapper.properties')}}
-        restore-keys: |
-          ${{runner.os}}-gradle-     
+  detekt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+      - run: chmod +x gradlew
+      - run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
+      - run: ./gradlew detekt
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+      - run: chmod +x gradlew
+      - run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
+      - run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ${{ github.workspace }}/app/google-services.json
+      - run: ./gradlew build -x ktlintCheck -x detekt
 
-    - name: Create LOCAL_PROPERTIES
-      run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
+  notify:
+    runs-on: ubuntu-latest
+    needs: [ktlint, detekt, build]
+    if: always()
+    steps:
+      - name: MemorySeal Android CI Discord Notification (Success)
+        uses: sarisia/actions-status-discord@v1
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        with:
+          title: "✅ MemorySeal-Android-CI 성공! ✅"
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: success
+          image: ${{ secrets.SUCCESS_IMAGE }}
+          color: 00FF00
+          url: "https://github.com/sarisia/actions-status-discord"
+          username: MemorySeal CI Bot
 
-    - name: Run ktlint
-      run: ./gradlew ktlintCheck
-
-    - name: Run detekt
-      run: ./gradlew detekt
-
-    - name: Create file
-      run: cat /home/runner/work/MemorySeal-Android/MemorySeal-Android/app/google-services.json | base64
-
-    - name: Putting data
-      env:
-        DATA: ${{ secrets.GOOGLE_SERVICES_JSON }}
-      run: echo $DATA > /home/runner/work/MemorySeal-Android/MemorySeal-Android/app/google-services.json
-
-    - name: Build with Gradle
-      run: ./gradlew build
-
-    - name: MemorySeal Android CI Discord Notification
-      uses: sarisia/actions-status-discord@v1
-      if: ${{ success() }}
-      with:
-        title: ✅ MemorySeal-Android-CI 성공! ✅
-        webhook: ${{ secrets.DISCORD_WEBHOOK }}
-        status: ${{ job.status }}
-        image: ${{ secrets.SUCCESS_IMAGE }}
-        color: 00FF00
-        url: "https://github.com/sarisia/actions-status-discord"
-        username: MemorySeal CI Bot
-
-    - name: MemorySeal Android CI Discord Notification
-      uses: sarisia/actions-status-discord@v1
-      if: ${{ failure() }}
-      with:
-        title: ❗️ MemorySeal-Android-CI 실패! ❗️
-        webhook: ${{ secrets.DISCORD_WEBHOOK }}
-        status: ${{ job.status }}
-        image: ${{ secrets.FAILED_IMAGE }}
-        color: 00FF00
-        url: "https://github.com/sarisia/actions-status-discord"
-        username: MemorySeal CI Bot
+      - name: MemorySeal Android CI Discord Notification (Failure)
+        uses: sarisia/actions-status-discord@v1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        with:
+          title: "❗️ MemorySeal-Android-CI 실패! ❗️"
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: failure
+          image: ${{ secrets.FAILED_IMAGE }}
+          color: FF0000
+          url: "https://github.com/sarisia/actions-status-discord"
+          username: MemorySeal CI Bot

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,7 +58,7 @@ jobs:
       - run: chmod +x gradlew
       - run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
       - run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ${{ github.workspace }}/app/google-services.json
-      - run: ./gradlew assembleDebug lintDebug --stacktrace
+      - run: ./gradlew buildDebug --stacktrace
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,7 +58,7 @@ jobs:
       - run: chmod +x gradlew
       - run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
       - run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ${{ github.workspace }}/app/google-services.json
-      - run: ./gradlew build
+      - run: ./gradlew assembleDebug lintDebug --stacktrace
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,7 +58,7 @@ jobs:
       - run: chmod +x gradlew
       - run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
       - run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ${{ github.workspace }}/app/google-services.json
-      - run: ./gradlew buildDebug --stacktrace
+      - run: ./gradlew assembleDebug --stacktrace
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,7 +58,7 @@ jobs:
       - run: chmod +x gradlew
       - run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
       - run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > ${{ github.workspace }}/app/google-services.json
-      - run: ./gradlew build -x ktlintCheck -x detekt
+      - run: ./gradlew assembleDebug lintDebug --stacktrace
 
   notify:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,9 @@ android.experimental.lint.heapSize=2g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
### 💡 개요
- #197 

### 📃 작업 내용
- Codin -> MemorySeal 이름 변경
- CI 병렬 처리
  - 데몬 비활성화 + 메모리 설정
  - 중복 실행 방지 및 ${{ github.workspace }} 사용으로 경로 하드코딩 제거
  - 캐시 처리 단일화 및 전략 수정
    - actions/cache@v4 -> gradle/actions/setup-gradle@v4 수정
    - PR 때는 cache-read-only 적용
  - job 세분화 (ktlint, detekt, build, notify)

### 💻 구현 화면
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/d439fb64-d44e-4e71-a136-a85250b564d0" width="300" /> | <img src="https://github.com/user-attachments/assets/f35bf3a7-cc5e-426e-8bca-f55d963a7c2d" width="300" />

### 🎸 기타
- 참고자료
  - https://github.com/YAPP-Github/Reed-Android/pull/284
  - https://angrypodo.tistory.com/26
  
- 결과 (해당 PR 머지 후 다음 PR CI 소요 시간)
<img width="623" height="180" alt="image" src="https://github.com/user-attachments/assets/27f3c1f4-72ed-41c7-9332-9ddf91766cc4" />
