### PR TITLE
🔀 :: (#211) HomeData Stability 수정

### DIFF
--- a/feature/home/src/main/java/com/idiotfrogs/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/idiotfrogs/home/HomeScreen.kt
@@ -62,11 +62,11 @@ fun HomeRoute(
         }
     }
 
-    when (uiState) {
+    when (val state = uiState) {
         UiState.Init -> {}
         is UiState.Success -> {
             HomeScreen(
-                uiState = uiState,
+                data = state.data,
                 onAction = viewModel::onAction
             )
         }
@@ -76,7 +76,7 @@ fun HomeRoute(
 
 @Composable
 fun HomeScreen(
-    uiState: UiState<HomeData>,
+    data: HomeData,
     onAction: (HomeAction) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -114,96 +114,88 @@ fun HomeScreen(
         }
     }
 
-    when (uiState) {
-        is UiState.Error -> {}
-        UiState.Init -> {}
-        is UiState.Success -> {
-            val data = uiState.data
-
-            Box {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MSTheme.color.bgNormal)
-                        .systemBarsPadding()
+    Box {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MSTheme.color.bgNormal)
+                .systemBarsPadding()
+        ) {
+            HomeHeader(
+                profileUrl = data.user?.profileImageUrl,
+                navigateToProfile = { onAction(HomeAction.NavigateToProfile) }
+            )
+            HomeTabBar(
+                selectedTab = currentTab,
+                onClick = { currentTab = it },
+            )
+            if (currentTab == HomeTab.CREATED) {
+                val host = data.capsules[TimeCapsuleRole.HOST].orEmpty()
+                LazyColumn(
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                    contentPadding = PaddingValues(top = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
-                    HomeHeader(
-                        profileUrl = data.user?.profileImageUrl,
-                        navigateToProfile = { onAction(HomeAction.NavigateToProfile) }
-                    )
-                    HomeTabBar(
-                        selectedTab = currentTab,
-                        onClick = { currentTab = it },
-                    )
-                    if (currentTab == HomeTab.CREATED) {
-                        val host = data.capsules[TimeCapsuleRole.HOST].orEmpty()
-                        LazyColumn(
-                            modifier = Modifier.padding(horizontal = 20.dp),
-                            contentPadding = PaddingValues(top = 24.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(16.dp),
-                        ) {
-                            items(host) {
-                                HomeTicket(
-                                    modifier = Modifier.noRippleClickable {
-                                        onAction(HomeAction.NavigateToDetail(it.timeCapsuleId))
-                                    },
-                                    countdown = it.openedAt.toDday(),
-                                    targetDate = it.openedAt.toYearMonthDay(),
-                                    title = it.title,
-                                    imageUrl = it.mainImageUrl
-                                )
-                            }
-                        }
-                    } else {
-                        val contributor = data.capsules[TimeCapsuleRole.CONTRIBUTOR].orEmpty()
-                        LazyColumn(
-                            modifier = Modifier.padding(horizontal = 20.dp),
-                            contentPadding = PaddingValues(top = 24.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(16.dp),
-                        ) {
-                            items(contributor) {
-                                HomeTicket(
-                                    modifier = Modifier.noRippleClickable {
-                                        onAction(HomeAction.NavigateToDetail(it.timeCapsuleId))
-                                    },
-                                    countdown = it.openedAt.toDday(),
-                                    targetDate = it.openedAt.toYearMonthDay(),
-                                    title = it.title,
-                                    imageUrl = ""
-                                )
-                            }
-                        }
+                    items(host) {
+                        HomeTicket(
+                            modifier = Modifier.noRippleClickable {
+                                onAction(HomeAction.NavigateToDetail(it.timeCapsuleId))
+                            },
+                            countdown = it.openedAt.toDday(),
+                            targetDate = it.openedAt.toYearMonthDay(),
+                            title = it.title,
+                            imageUrl = it.mainImageUrl
+                        )
                     }
                 }
-                MSDim(
-                    visible = showDim,
-                    onDismiss = {
-                        expanded = false
-                        showJoinContainer = false
+            } else {
+                val contributor = data.capsules[TimeCapsuleRole.CONTRIBUTOR].orEmpty()
+                LazyColumn(
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                    contentPadding = PaddingValues(top = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    items(contributor) {
+                        HomeTicket(
+                            modifier = Modifier.noRippleClickable {
+                                onAction(HomeAction.NavigateToDetail(it.timeCapsuleId))
+                            },
+                            countdown = it.openedAt.toDday(),
+                            targetDate = it.openedAt.toYearMonthDay(),
+                            title = it.title,
+                            imageUrl = ""
+                        )
                     }
-                )
-                MSMenuFab(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .navigationBarsPadding()
-                        .padding(end = 20.dp, bottom = 24.dp),
-                    expanded = expanded,
-                    hasFab = true,
-                    offset = DpOffset(x = 0.dp, y = (-16).dp),
-                    menuList = menuList,
-                    onClick = { expanded = !expanded },
-                    onDismiss = { expanded = false },
-                )
-                HomeJoinContainer(
-                    isShow = showJoinContainer,
-                    textFieldState = textFieldState,
-                    onJoin = { /** TODO: 타임 티켓 참여 */ },
-                    onCancel = { showJoinContainer = false }
-                )
+                }
             }
         }
+        MSDim(
+            visible = showDim,
+            onDismiss = {
+                expanded = false
+                showJoinContainer = false
+            }
+        )
+        MSMenuFab(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .navigationBarsPadding()
+                .padding(end = 20.dp, bottom = 24.dp),
+            expanded = expanded,
+            hasFab = true,
+            offset = DpOffset(x = 0.dp, y = (-16).dp),
+            menuList = menuList,
+            onClick = { expanded = !expanded },
+            onDismiss = { expanded = false },
+        )
+        HomeJoinContainer(
+            isShow = showJoinContainer,
+            textFieldState = textFieldState,
+            onJoin = { /** TODO: 타임 티켓 참여 */ },
+            onCancel = { showJoinContainer = false }
+        )
     }
 }
 
@@ -211,7 +203,7 @@ fun HomeScreen(
 @Composable
 fun HomeScreenPreview() {
     HomeScreen(
-        uiState = UiState.Init,
+        data = HomeData(),
         onAction = {},
     )
 }

--- a/feature/home/src/main/java/com/idiotfrogs/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/idiotfrogs/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.idiotfrogs.home
 
+import androidx.compose.runtime.Immutable
 import com.idiotfrogs.domain.usecase.timecapsule.GetMyTimeCapsuleUseCase
 import com.idiotfrogs.domain.usecase.user.GetMyProfileUseCase
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
@@ -67,6 +68,7 @@ class HomeViewModel @Inject constructor(
     }
 }
 
+@Immutable
 data class HomeData(
     val user: ProfileResponse? = null,
     val capsules: Map<TimeCapsuleRole, List<MyTimeCapsuleResponse>> = emptyMap()

--- a/feature/home/stability/home-debug.stability
+++ b/feature/home/stability/home-debug.stability
@@ -12,11 +12,11 @@ public fun com.idiotfrogs.home.HomeRoute(viewModel: com.idiotfrogs.home.HomeView
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.idiotfrogs.home.HomeScreen(uiState: com.idiotfrogs.util.UiState<com.idiotfrogs.home.HomeData>, onAction: kotlin.Function1<com.idiotfrogs.home.HomeAction, kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.idiotfrogs.home.HomeScreen(data: com.idiotfrogs.home.HomeData, onAction: kotlin.Function1<com.idiotfrogs.home.HomeAction, kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - uiState: UNSTABLE (has mutable properties or unstable members)
+    - data: STABLE (marked @Stable or @Immutable)
     - onAction: STABLE (function type)
 
 @Composable

--- a/feature/home/stability/home-release.stability
+++ b/feature/home/stability/home-release.stability
@@ -12,11 +12,11 @@ public fun com.idiotfrogs.home.HomeRoute(viewModel: com.idiotfrogs.home.HomeView
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.idiotfrogs.home.HomeScreen(uiState: com.idiotfrogs.util.UiState<com.idiotfrogs.home.HomeData>, onAction: kotlin.Function1<com.idiotfrogs.home.HomeAction, kotlin.Unit>): kotlin.Unit
-  skippable: false
+public fun com.idiotfrogs.home.HomeScreen(data: com.idiotfrogs.home.HomeData, onAction: kotlin.Function1<com.idiotfrogs.home.HomeAction, kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - uiState: UNSTABLE (has mutable properties or unstable members)
+    - data: STABLE (marked @Stable or @Immutable)
     - onAction: STABLE (function type)
 
 @Composable

--- a/feature/splash/src/main/java/com/idiotfrogs/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/com/idiotfrogs/splash/SplashViewModel.kt
@@ -20,30 +20,29 @@ class SplashViewModel @Inject constructor(
     override val container: Container<UiState<Unit>, SplashSideEffect> = container(
         initialState = UiState.Init,
         onCreate = {
-            safeLaunch {
-                /** todo: 데이터 로드 등 사전 작업 */
-                intent { reduce { UiState.Success(Unit) } }
-                autoLogin()
-            }
+            /** todo: 데이터 로드 등 사전 작업 */
+            intent { reduce { UiState.Success(Unit) } }
+            autoLogin()
         }
     )
 
     private fun autoLogin() {
-        intent {
+        safeLaunch {
             if (getAccessTokenUseCase.accessToken.firstOrNull() == null) {
-                postSideEffect(SplashSideEffect.NavigateToLogin)
+                intent { postSideEffect(SplashSideEffect.NavigateToLogin) }
             } else {
-                getMyProfileUseCase()
-                    .onSuccess {
+                val result = getMyProfileUseCase()
+                intent {
+                    result.onSuccess {
                         if (it.isOnboarding) {
                             postSideEffect(SplashSideEffect.NavigateToHome)
                         } else {
                             postSideEffect(SplashSideEffect.NavigateToSignUp)
                         }
-                    }
-                    .onFailure {
+                    }.onFailure {
                         postSideEffect(SplashSideEffect.NavigateToLogin)
                     }
+                }
             }
         }
     }


### PR DESCRIPTION
### 💡 개요
- #211 

### 📃 작업 내용
- HomeData Stability 수정
- Splash -> LoginRequired 크래시 수정

### 💻 구현 화면
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/dd080693-2905-4ea3-82bd-2f2c165452e9" width="360" /> | <img src="https://github.com/user-attachments/assets/3d4c7189-745e-4e85-b5c7-6dc903d195b5" width="360" />

### 🎸 기타
- HomeData에 @Immutable 해당 어노테이션을 적용시킴으로써 skippable 및 stable 상태로 변경하였지만, 해당 model 안에서 사용되는 map, list 또한 확실하게 Immutable Collection로 바꾸는 것도 고려해봤지만, 해당 사항만 적용을 해도 변경이 되었음으로 일단 바꾸지 않은 걸 기록만 해두고 현재와 같이 사용할까합니다.