### PR TITLE
🔀 :: (#228) NavEntryDecorator 적용

### DIFF
--- a/app/src/main/java/com/idiotfrogs/memoryseal/MainActivity.kt
+++ b/app/src/main/java/com/idiotfrogs/memoryseal/MainActivity.kt
@@ -13,8 +13,10 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.idiotfrogs.auth.login.LoginRoute
 import com.idiotfrogs.auth.signup.SignUpRoute
@@ -68,6 +70,10 @@ class MainActivity : ComponentActivity() {
                     ) { _ ->
                         NavDisplay(
                             backStack = backStack,
+                            entryDecorators = listOf(
+                                rememberSaveableStateHolderNavEntryDecorator(),
+                                rememberViewModelStoreNavEntryDecorator()
+                            ),
                             entryProvider = entryProvider {
                                 entry<Routes.Splash> { SplashRoute() }
                                 entry<Routes.Login> { LoginRoute() }

--- a/build-logic/src/main/kotlin/com/idiotfrogs/memoryseal/ComposeAndroid.kt
+++ b/build-logic/src/main/kotlin/com/idiotfrogs/memoryseal/ComposeAndroid.kt
@@ -30,6 +30,7 @@ internal fun Project.configureComposeAndroid(commonExtension: CommonExtension<*,
             add("implementation", libs.findLibrary("androidx-navigation3-runtime").get())
             add("implementation", libs.findLibrary("androidx-navigation3-ui").get())
             add("implementation", libs.findLibrary("hilt-lifecycle-viewmodel-compose").get())
+            add("implementation", libs.findLibrary("androidx-navigation3-lifecycle").get())
 
             add("implementation", libs.findLibrary("orbit-compose").get())
             add("implementation", libs.findLibrary("orbit-viewmodel").get())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidxComposeBom = "2024.12.01"
 orbit = "11.0.0"
 androidxNavigation = "2.8.8"
 androidxNavigation3 = "1.0.0"
+androidxLifecycle = "2.10.0"
 androidxDatastore = "1.2.0"
 firebaseBom = "33.8.0"
 kotlinxSerializationJson = "1.7.3"
@@ -64,6 +65,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 androidx-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "androidxNavigation3" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "androidxNavigation3" }
+androidx-navigation3-lifecycle = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "androidxLifecycle" }
 androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDatastore" }
 
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinDatetime" }


### PR DESCRIPTION
### 💡 개요
- #228 

### 📃 작업 내용
- rememberViewModelStoreNavEntryDecorator 적용

### 💻 구현 화면
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

### 🎸 기타
- `rememberSaveableStateHolderNavEntryDecorator()`는 구성 변경이나 프로세스 종료 상황에서도 NavEntry의 상태를 유지하도록 하며, 아무런 Decorator를 적지 않으면 기본으로 적용됩니다. ([레퍼런스](https://developer.android.com/guide/navigation/navigation-3/naventrydecorators#include-default))
- ViewModel은 기본적으로 가장 가까운 `ViewModelStore`에 스코프되며 이는 일반적으로 `Activity` 또는 `Fragment` 이나, `rememberViewModelStoreNavEntryDecorator()`를 사용하면 각 `NavEntry`로 제한됩니다. ([레퍼런스](https://developer.android.com/guide/navigation/navigation-3/save-state#alternative:-storing))