### PR TITLE
🔀 :: (#227) 공동작업자 관련 API 연동

### DIFF
--- a/core/model/src/main/java/com/idiotfrogs/model/timecapsule/PendingCollaboratorsRequest.kt
+++ b/core/model/src/main/java/com/idiotfrogs/model/timecapsule/PendingCollaboratorsRequest.kt
@@ -1,0 +1,8 @@
+package com.idiotfrogs.model.timecapsule
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PendingCollaboratorsRequest(
+    val code: String,
+)

--- a/core/model/src/main/java/com/idiotfrogs/model/timecapsule/ProcessCollaboratorRequest.kt
+++ b/core/model/src/main/java/com/idiotfrogs/model/timecapsule/ProcessCollaboratorRequest.kt
@@ -1,0 +1,8 @@
+package com.idiotfrogs.model.timecapsule
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ProcessCollaboratorRequest(
+    val isApproved: Boolean,
+)

--- a/core/model/src/main/java/com/idiotfrogs/model/timecapsule/RequestCollaboratorsResponse.kt
+++ b/core/model/src/main/java/com/idiotfrogs/model/timecapsule/RequestCollaboratorsResponse.kt
@@ -1,0 +1,14 @@
+package com.idiotfrogs.model.timecapsule
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestCollaboratorsResponse(
+    val requestId: Long,
+    val userId: Long,
+    val nickname: String,
+    val profileImageUrl: String,
+    val status: RequestStatus,
+)
+
+enum class RequestStatus { APPROVED, PENDING, REJECTED }

--- a/core/network/src/main/java/com/idiotfrogs/network/service/TimeCapsuleService.kt
+++ b/core/network/src/main/java/com/idiotfrogs/network/service/TimeCapsuleService.kt
@@ -1,12 +1,16 @@
 package com.idiotfrogs.network.service
 
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
+import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
+import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
+import com.idiotfrogs.model.timecapsule.RequestCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleInviteCodeResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleResponse
 import okhttp3.MultipartBody
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
@@ -37,4 +41,16 @@ interface TimeCapsuleService {
 
     @POST("time-capsules/{capsuleId}/invite")
     suspend fun getTimeCapsuleInviteCode(@Path("capsuleId") capsuleId: Long): TimeCapsuleInviteCodeResponse
+
+    @GET("time-capsules/request/{capsuleId}/requests")
+    suspend fun getRequestCollaborators(@Path("capsuleId") capsuleId: Long): List<RequestCollaboratorsResponse>
+
+    @POST("time-capsules/join-request")
+    suspend fun requestCollaborator(@Body body: PendingCollaboratorsRequest)
+
+    @POST("time-capsules/request/{requestId}/process")
+    suspend fun processRequest(
+        @Path("requestId") requestId: Long,
+        @Body body: ProcessCollaboratorRequest
+    )
 }

--- a/data/src/main/java/com/idiotfrogs/data/datasource/timecapsule/TimeCapsuleDataSource.kt
+++ b/data/src/main/java/com/idiotfrogs/data/datasource/timecapsule/TimeCapsuleDataSource.kt
@@ -1,6 +1,9 @@
 package com.idiotfrogs.data.datasource.timecapsule
 
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
+import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
+import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
+import com.idiotfrogs.model.timecapsule.RequestCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
@@ -23,4 +26,10 @@ interface TimeCapsuleDataSource {
     suspend fun getTimesCapsuleCollaborators(capsuleId: Long): List<TimeCapsuleCollaboratorsResponse>
 
     suspend fun getTimeCapsuleInviteCode(capsuleId: Long): TimeCapsuleInviteCodeResponse
+
+    suspend fun getRequestCollaborators(capsuleId: Long): List<RequestCollaboratorsResponse>
+
+    suspend fun requestCollaborator(body: PendingCollaboratorsRequest)
+
+    suspend fun processRequest(requestId: Long, body: ProcessCollaboratorRequest)
 }

--- a/data/src/main/java/com/idiotfrogs/data/datasource/timecapsule/TimeCapsuleDataSourceImpl.kt
+++ b/data/src/main/java/com/idiotfrogs/data/datasource/timecapsule/TimeCapsuleDataSourceImpl.kt
@@ -1,6 +1,9 @@
 package com.idiotfrogs.data.datasource.timecapsule
 
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
+import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
+import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
+import com.idiotfrogs.model.timecapsule.RequestCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
@@ -41,5 +44,17 @@ class TimeCapsuleDataSourceImpl @Inject constructor(
 
     override suspend fun getTimeCapsuleInviteCode(capsuleId: Long): TimeCapsuleInviteCodeResponse {
         return timeCapsuleService.getTimeCapsuleInviteCode(capsuleId)
+    }
+
+    override suspend fun getRequestCollaborators(capsuleId: Long): List<RequestCollaboratorsResponse> {
+        return timeCapsuleService.getRequestCollaborators(capsuleId)
+    }
+
+    override suspend fun requestCollaborator(body: PendingCollaboratorsRequest) {
+        return timeCapsuleService.requestCollaborator(body)
+    }
+
+    override suspend fun processRequest(requestId: Long, body: ProcessCollaboratorRequest) {
+        return timeCapsuleService.processRequest(requestId , body)
     }
 }

--- a/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepository.kt
+++ b/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepository.kt
@@ -1,6 +1,9 @@
 package com.idiotfrogs.data.repository.timecapsule
 
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
+import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
+import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
+import com.idiotfrogs.model.timecapsule.RequestCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
@@ -23,4 +26,10 @@ interface TimeCapsuleRepository {
     suspend fun getTimesCapsuleCollaborators(capsuleId: Long): List<TimeCapsuleCollaboratorsResponse>
 
     suspend fun getTimeCapsuleInviteCode(capsuleId: Long): TimeCapsuleInviteCodeResponse
+
+    suspend fun getRequestCollaborators(capsuleId: Long): List<RequestCollaboratorsResponse>
+
+    suspend fun requestCollaborator(body: PendingCollaboratorsRequest)
+
+    suspend fun processRequest(requestId: Long, body: ProcessCollaboratorRequest)
 }

--- a/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepositoryImpl.kt
+++ b/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepositoryImpl.kt
@@ -2,6 +2,9 @@ package com.idiotfrogs.data.repository.timecapsule
 
 import com.idiotfrogs.data.datasource.timecapsule.TimeCapsuleDataSource
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
+import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
+import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
+import com.idiotfrogs.model.timecapsule.RequestCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
@@ -46,5 +49,17 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
 
     override suspend fun getTimeCapsuleInviteCode(capsuleId: Long): TimeCapsuleInviteCodeResponse {
         return timeCapsuleDataSource.getTimeCapsuleInviteCode(capsuleId)
+    }
+
+    override suspend fun getRequestCollaborators(capsuleId: Long): List<RequestCollaboratorsResponse> {
+        return timeCapsuleDataSource.getRequestCollaborators(capsuleId)
+    }
+
+    override suspend fun requestCollaborator(body: PendingCollaboratorsRequest) {
+        return timeCapsuleDataSource.requestCollaborator(body)
+    }
+
+    override suspend fun processRequest(requestId: Long, body: ProcessCollaboratorRequest) {
+        return timeCapsuleDataSource.processRequest(requestId, body)
     }
 }

--- a/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/GetRequestCollaboratorsUseCase.kt
+++ b/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/GetRequestCollaboratorsUseCase.kt
@@ -1,0 +1,14 @@
+package com.idiotfrogs.domain.usecase.timecapsule
+
+import com.idiotfrogs.data.repository.timecapsule.TimeCapsuleRepository
+import com.idiotfrogs.model.timecapsule.RequestCollaboratorsResponse
+import com.idiotfrogs.util.safeCatching
+import javax.inject.Inject
+
+class GetRequestCollaboratorsUseCase @Inject constructor(
+    private val timeCapsuleRepository: TimeCapsuleRepository
+) {
+    suspend operator fun invoke(capsuleId: Long): Result<List<RequestCollaboratorsResponse>> = safeCatching {
+        timeCapsuleRepository.getRequestCollaborators(capsuleId)
+    }
+}

--- a/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/ProcessRequestUseCase.kt
+++ b/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/ProcessRequestUseCase.kt
@@ -1,0 +1,14 @@
+package com.idiotfrogs.domain.usecase.timecapsule
+
+import com.idiotfrogs.data.repository.timecapsule.TimeCapsuleRepository
+import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
+import com.idiotfrogs.util.safeCatching
+import javax.inject.Inject
+
+class ProcessRequestUseCase @Inject constructor(
+    private val timeCapsuleRepository: TimeCapsuleRepository
+) {
+    suspend operator fun invoke(requestId: Long, body: ProcessCollaboratorRequest): Result<Unit> = safeCatching {
+        timeCapsuleRepository.processRequest(requestId, body)
+    }
+}

--- a/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/RequestCollaboratorUseCase.kt
+++ b/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/RequestCollaboratorUseCase.kt
@@ -1,0 +1,14 @@
+package com.idiotfrogs.domain.usecase.timecapsule
+
+import com.idiotfrogs.data.repository.timecapsule.TimeCapsuleRepository
+import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
+import com.idiotfrogs.util.safeCatching
+import javax.inject.Inject
+
+class RequestCollaboratorUseCase @Inject constructor(
+    private val timeCapsuleRepository: TimeCapsuleRepository
+) {
+    suspend operator fun invoke(body: PendingCollaboratorsRequest): Result<Unit> = safeCatching {
+        timeCapsuleRepository.requestCollaborator(body)
+    }
+}

--- a/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
@@ -389,7 +389,7 @@ fun DetailScreen(
             MembarListItem(
                 nickName = myData?.nickname + " (나)",
                 profileImageUrl = myData?.profileImageUrl ?: "",
-                isMembar = false
+                isMembar = if (myData?.contributorRole == TimeCapsuleRole.HOST) false else true
             )
             Spacer(Modifier.height(16.dp))
             HorizontalDivider(

--- a/feature/friend/src/main/java/com/idiotfrogs/friend/FriendScreen.kt
+++ b/feature/friend/src/main/java/com/idiotfrogs/friend/FriendScreen.kt
@@ -3,6 +3,7 @@ package com.idiotfrogs.friend
 import android.content.ClipData
 import android.content.Intent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,6 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,6 +43,7 @@ import com.idiotfrogs.designsystem.theme.MSTheme
 import com.idiotfrogs.designsystem.util.noRippleClickable
 import com.idiotfrogs.friend.component.FriendListItem
 import com.idiotfrogs.friend.component.FriendTopNotification
+import com.idiotfrogs.model.timecapsule.RequestStatus
 import com.idiotfrogs.navigation.LocalComposeMSNavigator
 import com.idiotfrogs.resource.R
 import com.idiotfrogs.util.UiState
@@ -52,11 +56,18 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 @Composable
 fun FriendRoute(
     capsuleId: Long,
-    viewModel: FriendViewModel = hiltViewModel()
+    viewModel: FriendViewModel = hiltViewModel<FriendViewModel, FriendViewModel.Factory>(key = capsuleId.toString()) { it.create(capsuleId) }
 ) {
     val navigator = LocalComposeMSNavigator.current
     val clipboard = LocalClipboard.current
     val uiState by viewModel.collectAsState()
+    var toastState by remember { mutableStateOf(FriendScreenActionState.IDLE) }
+
+    LaunchedEffect(toastState) {
+        if (toastState == FriendScreenActionState.IDLE) return@LaunchedEffect
+        delay(2000L)
+        toastState = FriendScreenActionState.IDLE
+    }
 
     viewModel.collectSideEffect { event ->
         when (event) {
@@ -65,14 +76,17 @@ fun FriendRoute(
                 val clipData = ClipData.newPlainText("inviteCode", event.code)
                 clipboard.setClipEntry(ClipEntry(clipData))
             }
+            is FriendSideEffect.ShowToast -> toastState = event.state
         }
     }
 
-    when (uiState) {
+    when (val state = uiState) {
         UiState.Init -> Unit
         is UiState.Success -> {
             FriendScreen(
                 capsuleId = capsuleId,
+                toastState = toastState,
+                data = state.data,
                 onAction = viewModel::onAction
             )
         }
@@ -83,14 +97,13 @@ fun FriendRoute(
 @Composable
 fun FriendScreen(
     capsuleId: Long,
-    modifier: Modifier = Modifier,
+    toastState: FriendScreenActionState,
+    data: CollaboratorsData,
     onAction: (FriendAction) -> Unit,
 ) {
     val context = LocalContext.current
 
     val hazeState = rememberHazeState()
-    var isEmpty by remember { mutableStateOf(false) }
-    var action by remember { mutableStateOf(FriendScreenActionState.IDLE) }
     var expanded by remember { mutableStateOf(false) }
     val menuList by remember {
         mutableStateOf(
@@ -122,17 +135,12 @@ fun FriendScreen(
                 },
                 MSMenuFabModel("참여 코드 복사") {
                     expanded = false
-                    action = FriendScreenActionState.COPY
                     onAction(FriendAction.CopyInviteCode(capsuleId))
                 },
             )
         )
     }
-
-    LaunchedEffect(action) {
-        delay(1000L)
-        action = FriendScreenActionState.IDLE
-    }
+    val pendingCollaborators = data.collaborators.filter { it.status == RequestStatus.PENDING }
 
     Box {
         MSMenuFab(
@@ -148,7 +156,7 @@ fun FriendScreen(
             onDismiss = { expanded = false },
         )
 
-        if (action != FriendScreenActionState.IDLE) {
+        if (toastState != FriendScreenActionState.IDLE) {
             FriendTopNotification(
                 modifier = Modifier
                     .padding(horizontal = 20.dp)
@@ -156,12 +164,12 @@ fun FriendScreen(
                     .systemBarsPadding()
                     .zIndex(1f),
                 hazeState = hazeState,
-                action = action,
+                action = toastState,
             )
         }
 
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxSize()
                 .hazeSource(hazeState)
                 .background(MSTheme.color.white)
@@ -180,7 +188,7 @@ fun FriendScreen(
                     modifier = Modifier.noRippleClickable { expanded = true }
                 )
             }
-            if (isEmpty) {
+            if (pendingCollaborators.isEmpty()) {
                 Spacer(Modifier.height(25.dp))
                 Icon(
                     painter = painterResource(R.drawable.img_friend_empty_plus),
@@ -198,21 +206,19 @@ fun FriendScreen(
                     textAlign = TextAlign.Center
                 )
             } else {
-                repeat(10) { // TODO 테스트용 코드 -> 추 후 실제 list 변경 필요
-                    Spacer(Modifier.height(8.dp))
-                    FriendListItem(
-                        nickName = when (it) {
-                            0 -> "파란 바나나"
-                            1 -> "검정 복숭아"
-                            2 -> "별 모양 파인애플"
-                            3 -> "초코 체리"
-                            4 -> "자두 수박"
-                            else -> "민트 네모 수박"
-                        },
-                        onAccept = { action = FriendScreenActionState.ACCEPT },
-                        onReject = { action = FriendScreenActionState.REJECT }
-                    )
-                    Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(16.dp))
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(
+                        items = pendingCollaborators,
+                        key = { it.requestId },
+                    ) { item ->
+                        FriendListItem(
+                            nickName = item.nickname,
+                            profileImageUrl = item.profileImageUrl,
+                            onAccept = { onAction(FriendAction.ProcessRequest(item.requestId, true)) },
+                            onReject = { onAction(FriendAction.ProcessRequest(item.requestId, false)) },
+                        )
+                    }
                 }
             }
         }
@@ -224,6 +230,8 @@ fun FriendScreen(
 fun FriendScreenPreview() {
     FriendScreen(
         capsuleId = 0L,
+        toastState = FriendScreenActionState.IDLE,
+        data = CollaboratorsData(),
         onAction = {}
     )
 }

--- a/feature/friend/src/main/java/com/idiotfrogs/friend/FriendScreen.kt
+++ b/feature/friend/src/main/java/com/idiotfrogs/friend/FriendScreen.kt
@@ -3,12 +3,11 @@ package com.idiotfrogs.friend
 import android.content.ClipData
 import android.content.Intent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -168,7 +167,7 @@ fun FriendScreen(
             )
         }
 
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .hazeSource(hazeState)
@@ -177,48 +176,55 @@ fun FriendScreen(
                 .padding(horizontal = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            MSDetailHeader(
-                title = "맴버 추가",
-                navigateToBack = { onAction(FriendAction.NavigateToBack) },
-                paddingValues = PaddingValues(horizontal = 0.dp, vertical = 16.dp)
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_plus),
-                    contentDescription = "Back",
-                    modifier = Modifier.noRippleClickable { expanded = true }
-                )
+            item {
+                MSDetailHeader(
+                    title = "멤버 추가",
+                    navigateToBack = { onAction(FriendAction.NavigateToBack) },
+                    paddingValues = PaddingValues(horizontal = 0.dp, vertical = 16.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_plus),
+                        contentDescription = "메뉴 열기",
+                        modifier = Modifier.noRippleClickable { expanded = true }
+                    )
+                }
             }
+
             if (pendingCollaborators.isEmpty()) {
-                Spacer(Modifier.height(25.dp))
-                Icon(
-                    painter = painterResource(R.drawable.img_friend_empty_plus),
-                    contentDescription = "emptyIcon",
-                    tint = MSTheme.color.greyG1,
-                    modifier = Modifier
-                        .align(Alignment.End)
-                        .padding(end = 40.dp)
-                )
-                Spacer(Modifier.height(32.dp))
-                MSText(
-                    text = "대기중인 맴버가 없습니다.\n" + "코드 또는 링크로 맴버를 초대해보세요.",
-                    color = MSTheme.color.greyG4,
-                    fontWeight = FontWeight.Normal,
-                    textAlign = TextAlign.Center
-                )
-            } else {
-                Spacer(Modifier.height(16.dp))
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    items(
-                        items = pendingCollaborators,
-                        key = { it.requestId },
-                    ) { item ->
-                        FriendListItem(
-                            nickName = item.nickname,
-                            profileImageUrl = item.profileImageUrl,
-                            onAccept = { onAction(FriendAction.ProcessRequest(item.requestId, true)) },
-                            onReject = { onAction(FriendAction.ProcessRequest(item.requestId, false)) },
+                item {
+                    Spacer(Modifier.height(25.dp))
+                    Box(Modifier.fillMaxWidth()) {
+                        Icon(
+                            painter = painterResource(R.drawable.img_friend_empty_plus),
+                            contentDescription = "emptyIcon",
+                            tint = MSTheme.color.greyG1,
+                            modifier = Modifier
+                                .align(Alignment.CenterEnd)
+                                .padding(end = 40.dp)
                         )
                     }
+                    Spacer(Modifier.height(32.dp))
+                    MSText(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = "대기중인 멤버가 없습니다.\n코드 또는 링크로 멤버를 초대해보세요.",
+                        color = MSTheme.color.greyG4,
+                        fontWeight = FontWeight.Normal,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            } else {
+                item { Spacer(Modifier.height(16.dp)) }
+                items(
+                    items = pendingCollaborators,
+                    key = { it.requestId },
+                ) { item ->
+                    FriendListItem(
+                        modifier = Modifier.padding(bottom = 8.dp),
+                        nickName = item.nickname,
+                        profileImageUrl = item.profileImageUrl,
+                        onAccept = { onAction(FriendAction.ProcessRequest(item.requestId, true)) },
+                        onReject = { onAction(FriendAction.ProcessRequest(item.requestId, false)) },
+                    )
                 }
             }
         }

--- a/feature/friend/src/main/java/com/idiotfrogs/friend/FriendViewModel.kt
+++ b/feature/friend/src/main/java/com/idiotfrogs/friend/FriendViewModel.kt
@@ -8,6 +8,8 @@ import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
 import com.idiotfrogs.model.timecapsule.RequestCollaboratorsResponse
 import com.idiotfrogs.util.UiState
 import com.idiotfrogs.util.base.BaseViewModel
+import com.idiotfrogs.util.sideEffect.RefreshEvent
+import com.idiotfrogs.util.sideEffect.RefreshSideEffect
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -58,6 +60,7 @@ class FriendViewModel @AssistedInject constructor(
                 )
             }
             fetchFriend()
+            RefreshSideEffect.tryEmit(RefreshEvent.Detail(capsuleId))
         }.onFailure {
             // TODO 에러 처리 어떻게 할지 논의 필요.
         }

--- a/feature/friend/src/main/java/com/idiotfrogs/friend/FriendViewModel.kt
+++ b/feature/friend/src/main/java/com/idiotfrogs/friend/FriendViewModel.kt
@@ -1,31 +1,61 @@
 package com.idiotfrogs.friend
 
+import androidx.compose.runtime.Immutable
+import com.idiotfrogs.domain.usecase.timecapsule.GetRequestCollaboratorsUseCase
 import com.idiotfrogs.domain.usecase.timecapsule.GetTimeCapsuleInviteCodeUseCase
+import com.idiotfrogs.domain.usecase.timecapsule.ProcessRequestUseCase
+import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
+import com.idiotfrogs.model.timecapsule.RequestCollaboratorsResponse
 import com.idiotfrogs.util.UiState
 import com.idiotfrogs.util.base.BaseViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.viewmodel.container
-import javax.inject.Inject
 
-@HiltViewModel
-class FriendViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = FriendViewModel.Factory::class)
+class FriendViewModel @AssistedInject constructor(
+    @Assisted private val capsuleId: Long,
     private val getTimeCapsuleInviteCodeUseCase: GetTimeCapsuleInviteCodeUseCase,
-) : BaseViewModel<UiState<Unit>, FriendSideEffect, FriendAction>() {
+    private val processRequestUseCase: ProcessRequestUseCase,
+    private val getRequestCollaboratorsUseCase: GetRequestCollaboratorsUseCase,
+) : BaseViewModel<UiState<CollaboratorsData>, FriendSideEffect, FriendAction>() {
 
-    override val container: Container<UiState<Unit>, FriendSideEffect> = container(
+    override val container: Container<UiState<CollaboratorsData>, FriendSideEffect> = container(
         initialState = UiState.Init,
-        onCreate = {
-            safeLaunch {
-                // TODO 초기 데이터 로딩
-                intent { reduce { UiState.Success(Unit) } }
-            }
-        }
+        onCreate = { fetchFriend() }
     )
+
+    private fun fetchFriend() = safeLaunch {
+        getRequestCollaboratorsUseCase(capsuleId).onSuccess {
+            intent { reduce { UiState.Success(CollaboratorsData(it)) } }
+        }.onFailure {
+            intent { reduce { UiState.Error(it.message) } }
+        }
+    }
 
     private fun getTimeCapsuleInviteCode(capsuleId: Long) = safeLaunch {
         getTimeCapsuleInviteCodeUseCase(capsuleId).onSuccess {
             intent { postSideEffect(FriendSideEffect.CopyInviteCode(it.code)) }
+            intent { postSideEffect(FriendSideEffect.ShowToast(FriendScreenActionState.COPY)) }
+        }.onFailure {
+            // TODO 에러 처리 어떻게 할지 논의 필요.
+        }
+    }
+
+    private fun processRequest(requestId: Long, body: ProcessCollaboratorRequest) = safeLaunch {
+        processRequestUseCase(requestId, body).onSuccess {
+            intent {
+                postSideEffect(
+                    FriendSideEffect.ShowToast(
+                        if (body.isApproved) FriendScreenActionState.ACCEPT
+                        else FriendScreenActionState.REJECT
+                    )
+                )
+            }
+            fetchFriend()
         }.onFailure {
             // TODO 에러 처리 어떻게 할지 논의 필요.
         }
@@ -35,18 +65,33 @@ class FriendViewModel @Inject constructor(
         when (action) {
             FriendAction.NavigateToBack -> intent { postSideEffect(FriendSideEffect.NavigateToBack) }
             is FriendAction.CopyInviteCode -> getTimeCapsuleInviteCode(action.capsuleId)
+            is FriendAction.ProcessRequest -> processRequest(action.requestId, ProcessCollaboratorRequest(action.isApproved))
         }
     }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(capsuleId: Long): FriendViewModel
+    }
 }
+
+@Immutable
+data class CollaboratorsData(
+    val collaborators: List<RequestCollaboratorsResponse> = emptyList()
+)
 
 sealed interface FriendAction {
     data object NavigateToBack : FriendAction
 
     data class CopyInviteCode(val capsuleId: Long) : FriendAction
+
+    data class ProcessRequest(val requestId: Long, val isApproved: Boolean) : FriendAction
 }
 
 sealed interface FriendSideEffect {
     data object NavigateToBack : FriendSideEffect
 
     data class CopyInviteCode(val code: String) : FriendSideEffect
+
+    data class ShowToast(val state: FriendScreenActionState) : FriendSideEffect
 }

--- a/feature/friend/src/main/java/com/idiotfrogs/friend/FriendViewModel.kt
+++ b/feature/friend/src/main/java/com/idiotfrogs/friend/FriendViewModel.kt
@@ -38,8 +38,10 @@ class FriendViewModel @AssistedInject constructor(
 
     private fun getTimeCapsuleInviteCode(capsuleId: Long) = safeLaunch {
         getTimeCapsuleInviteCodeUseCase(capsuleId).onSuccess {
-            intent { postSideEffect(FriendSideEffect.CopyInviteCode(it.code)) }
-            intent { postSideEffect(FriendSideEffect.ShowToast(FriendScreenActionState.COPY)) }
+            intent {
+                postSideEffect(FriendSideEffect.CopyInviteCode(it.code))
+                postSideEffect(FriendSideEffect.ShowToast(FriendScreenActionState.COPY))
+            }
         }.onFailure {
             // TODO 에러 처리 어떻게 할지 논의 필요.
         }

--- a/feature/friend/src/main/java/com/idiotfrogs/friend/component/FriendListItem.kt
+++ b/feature/friend/src/main/java/com/idiotfrogs/friend/component/FriendListItem.kt
@@ -1,6 +1,5 @@
 package com.idiotfrogs.friend.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,22 +7,24 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.idiotfrogs.designsystem.component.MSText
 import com.idiotfrogs.designsystem.theme.MSTheme
 import com.idiotfrogs.designsystem.util.noRippleClickable
-import com.idiotfrogs.resource.R
+import com.skydoves.landscapist.glide.GlideImage
 
 @Composable
 fun FriendListItem(
     nickName: String,
+    profileImageUrl: String,
     onAccept: () -> Unit,
     onReject: () -> Unit,
     modifier: Modifier = Modifier,
@@ -32,10 +33,11 @@ fun FriendListItem(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Image( // TODO 추 후 AsyncImage 변경 필요
-            painter = painterResource(R.drawable.img_profile_32),
-            contentDescription = "프로필",
-            modifier = Modifier.size(48.dp)
+        GlideImage(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape),
+            imageModel = { profileImageUrl }
         )
         Spacer(Modifier.width(8.dp))
         MSText(
@@ -79,6 +81,7 @@ fun FriendListItem(
 fun FriendListItemPreview() {
     FriendListItem(
         "nickName",
+        "profileImageUrl",
         onAccept = {},
         onReject = {},
     )

--- a/feature/friend/stability/friend-debug.stability
+++ b/feature/friend/stability/friend-debug.stability
@@ -13,20 +13,22 @@ public fun com.idiotfrogs.friend.FriendRoute(capsuleId: kotlin.Long, viewModel: 
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.idiotfrogs.friend.FriendScreen(capsuleId: kotlin.Long, modifier: androidx.compose.ui.Modifier, onAction: kotlin.Function1<com.idiotfrogs.friend.FriendAction, kotlin.Unit>): kotlin.Unit
+public fun com.idiotfrogs.friend.FriendScreen(capsuleId: kotlin.Long, toastState: com.idiotfrogs.friend.FriendScreenActionState, data: com.idiotfrogs.friend.CollaboratorsData, onAction: kotlin.Function1<com.idiotfrogs.friend.FriendAction, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - capsuleId: STABLE (primitive type)
-    - modifier: STABLE (marked @Stable or @Immutable)
+    - toastState: STABLE (class with no mutable properties)
+    - data: STABLE (marked @Stable or @Immutable)
     - onAction: STABLE (function type)
 
 @Composable
-public fun com.idiotfrogs.friend.component.FriendListItem(nickName: kotlin.String, onAccept: kotlin.Function0<kotlin.Unit>, onReject: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.idiotfrogs.friend.component.FriendListItem(nickName: kotlin.String, profileImageUrl: kotlin.String, onAccept: kotlin.Function0<kotlin.Unit>, onReject: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - nickName: STABLE (String is immutable)
+    - profileImageUrl: STABLE (String is immutable)
     - onAccept: STABLE (function type)
     - onReject: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)

--- a/feature/friend/stability/friend-release.stability
+++ b/feature/friend/stability/friend-release.stability
@@ -13,20 +13,22 @@ public fun com.idiotfrogs.friend.FriendRoute(capsuleId: kotlin.Long, viewModel: 
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.idiotfrogs.friend.FriendScreen(capsuleId: kotlin.Long, modifier: androidx.compose.ui.Modifier, onAction: kotlin.Function1<com.idiotfrogs.friend.FriendAction, kotlin.Unit>): kotlin.Unit
+public fun com.idiotfrogs.friend.FriendScreen(capsuleId: kotlin.Long, toastState: com.idiotfrogs.friend.FriendScreenActionState, data: com.idiotfrogs.friend.CollaboratorsData, onAction: kotlin.Function1<com.idiotfrogs.friend.FriendAction, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - capsuleId: STABLE (primitive type)
-    - modifier: STABLE (marked @Stable or @Immutable)
+    - toastState: STABLE (class with no mutable properties)
+    - data: STABLE (marked @Stable or @Immutable)
     - onAction: STABLE (function type)
 
 @Composable
-public fun com.idiotfrogs.friend.component.FriendListItem(nickName: kotlin.String, onAccept: kotlin.Function0<kotlin.Unit>, onReject: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.idiotfrogs.friend.component.FriendListItem(nickName: kotlin.String, profileImageUrl: kotlin.String, onAccept: kotlin.Function0<kotlin.Unit>, onReject: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - nickName: STABLE (String is immutable)
+    - profileImageUrl: STABLE (String is immutable)
     - onAccept: STABLE (function type)
     - onReject: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)

--- a/feature/home/src/main/java/com/idiotfrogs/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/idiotfrogs/home/HomeScreen.kt
@@ -1,18 +1,22 @@
 package com.idiotfrogs.home
 
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
@@ -28,11 +32,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.idiotfrogs.designsystem.component.MSDim
 import com.idiotfrogs.designsystem.component.MSMenuFab
+import com.idiotfrogs.designsystem.component.MSText
+import com.idiotfrogs.designsystem.component.MSToast
 import com.idiotfrogs.designsystem.model.MSMenuFabModel
 import com.idiotfrogs.designsystem.theme.MSTheme
 import com.idiotfrogs.designsystem.util.DevicePreview
@@ -48,6 +56,10 @@ import com.idiotfrogs.navigation.Routes
 import com.idiotfrogs.util.UiState
 import com.idiotfrogs.extension.toDday
 import com.idiotfrogs.extension.toYearMonthDay
+import com.idiotfrogs.resource.R
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
+import kotlinx.coroutines.delay
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -57,12 +69,20 @@ fun HomeRoute(
 ) {
     val navigator = LocalComposeMSNavigator.current
     val uiState by viewModel.collectAsState()
+    var showToast by remember { mutableStateOf(false) }
+
+    LaunchedEffect(showToast) {
+        if (!showToast) return@LaunchedEffect
+        delay(2000L)
+        showToast = false
+    }
 
     viewModel.collectSideEffect {
         when (it) {
             HomeSideEffect.NavigateToCreate -> navigator.navigate(Routes.Create)
             HomeSideEffect.NavigateToProfile -> navigator.navigate(Routes.Profile)
             is HomeSideEffect.NavigateToDetail -> navigator.navigate(Routes.Detail(it.id))
+            HomeSideEffect.ShowToast -> showToast = true
         }
     }
 
@@ -70,6 +90,7 @@ fun HomeRoute(
         UiState.Init -> {}
         is UiState.Success -> {
             HomeScreen(
+                showToast = showToast,
                 data = state.data,
                 onAction = viewModel::onAction
             )
@@ -80,9 +101,11 @@ fun HomeRoute(
 
 @Composable
 fun HomeScreen(
+    showToast: Boolean,
     data: HomeData,
     onAction: (HomeAction) -> Unit,
 ) {
+    val hazeState = rememberHazeState()
     var expanded by remember { mutableStateOf(false) }
     var currentTab by remember { mutableStateOf(HomeTab.CREATED) }
     var showJoinContainer by remember { mutableStateOf(false) }
@@ -132,11 +155,34 @@ fun HomeScreen(
     }
 
     Box {
+        if (showToast) {
+            MSToast(
+                modifier = Modifier
+                    .padding(horizontal = 20.dp)
+                    .align(Alignment.BottomCenter)
+                    .systemBarsPadding()
+                    .zIndex(1f),
+                hazeState = hazeState,
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.img_friend_accept),
+                    contentDescription = "알림",
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                MSText(
+                    text = "타임 캡슐 참여 요청이 완료되었어요.",
+                    color = MSTheme.color.white
+                )
+            }
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .background(MSTheme.color.bgNormal)
                 .systemBarsPadding()
+                .hazeSource(hazeState)
         ) {
             HomeHeader(
                 profileUrl = data.user?.profileImageUrl,
@@ -202,7 +248,7 @@ fun HomeScreen(
         HomeJoinContainer(
             isShow = showJoinContainer,
             textFieldState = textFieldState,
-            onJoin = { /** TODO: 타임 티켓 참여 */ },
+            onJoin = { onAction(HomeAction.RequestCollaborator(textFieldState.text.toString())) },
             onCancel = { showJoinContainer = false }
         )
     }
@@ -212,6 +258,7 @@ fun HomeScreen(
 @Composable
 fun HomeScreenPreview() {
     HomeScreen(
+        showToast = false,
         data = HomeData(),
         onAction = {},
     )

--- a/feature/home/src/main/java/com/idiotfrogs/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/idiotfrogs/home/HomeViewModel.kt
@@ -2,8 +2,10 @@ package com.idiotfrogs.home
 
 import androidx.compose.runtime.Immutable
 import com.idiotfrogs.domain.usecase.timecapsule.GetMyTimeCapsuleUseCase
+import com.idiotfrogs.domain.usecase.timecapsule.RequestCollaboratorUseCase
 import com.idiotfrogs.domain.usecase.user.GetMyProfileUseCase
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
+import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleRole
 import com.idiotfrogs.model.user.ProfileResponse
 import com.idiotfrogs.util.UiState
@@ -20,6 +22,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val getMyTimeCapsuleUseCase: GetMyTimeCapsuleUseCase,
     private val getMyProfileUseCase: GetMyProfileUseCase,
+    private val requestCollaboratorUseCase: RequestCollaboratorUseCase,
 ): BaseViewModel<UiState<HomeData>, HomeSideEffect, HomeAction>() {
 
     override val container: Container<UiState<HomeData>, HomeSideEffect> = container(
@@ -57,12 +60,21 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    private fun requestCollaborator(body: PendingCollaboratorsRequest) = safeLaunch {
+        requestCollaboratorUseCase(body).onSuccess {
+            intent { postSideEffect(HomeSideEffect.ShowToast) }
+        }.onFailure {
+            // TODO 추 후 에러 핸들링 맞추기 (공동 작업자 이미 신청한 사용자라면 409)
+        }
+    }
+
     override fun onAction(action: HomeAction) {
         intent {
             when (action) {
                 HomeAction.NavigateToCreate -> postSideEffect(HomeSideEffect.NavigateToCreate)
                 HomeAction.NavigateToProfile -> postSideEffect(HomeSideEffect.NavigateToProfile)
                 is HomeAction.NavigateToDetail -> postSideEffect(HomeSideEffect.NavigateToDetail(action.id))
+                is HomeAction.RequestCollaborator -> requestCollaborator(PendingCollaboratorsRequest(action.code))
             }
         }
     }
@@ -78,10 +90,14 @@ sealed interface HomeAction {
     data object NavigateToCreate : HomeAction
     data object NavigateToProfile : HomeAction
     data class NavigateToDetail(val id: Long) : HomeAction
+
+    data class RequestCollaborator(val code: String) : HomeAction
 }
 
 sealed interface HomeSideEffect {
     data object NavigateToCreate : HomeSideEffect
     data object NavigateToProfile : HomeSideEffect
     data class NavigateToDetail(val id: Long) : HomeSideEffect
+
+    data object ShowToast : HomeSideEffect
 }

--- a/feature/home/stability/home-debug.stability
+++ b/feature/home/stability/home-debug.stability
@@ -12,10 +12,11 @@ public fun com.idiotfrogs.home.HomeRoute(viewModel: com.idiotfrogs.home.HomeView
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.idiotfrogs.home.HomeScreen(data: com.idiotfrogs.home.HomeData, onAction: kotlin.Function1<com.idiotfrogs.home.HomeAction, kotlin.Unit>): kotlin.Unit
+public fun com.idiotfrogs.home.HomeScreen(showToast: kotlin.Boolean, data: com.idiotfrogs.home.HomeData, onAction: kotlin.Function1<com.idiotfrogs.home.HomeAction, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - showToast: STABLE (primitive type)
     - data: STABLE (marked @Stable or @Immutable)
     - onAction: STABLE (function type)
 

--- a/feature/home/stability/home-release.stability
+++ b/feature/home/stability/home-release.stability
@@ -12,10 +12,11 @@ public fun com.idiotfrogs.home.HomeRoute(viewModel: com.idiotfrogs.home.HomeView
     - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.idiotfrogs.home.HomeScreen(data: com.idiotfrogs.home.HomeData, onAction: kotlin.Function1<com.idiotfrogs.home.HomeAction, kotlin.Unit>): kotlin.Unit
+public fun com.idiotfrogs.home.HomeScreen(showToast: kotlin.Boolean, data: com.idiotfrogs.home.HomeData, onAction: kotlin.Function1<com.idiotfrogs.home.HomeAction, kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
+    - showToast: STABLE (primitive type)
     - data: STABLE (marked @Stable or @Immutable)
     - onAction: STABLE (function type)
 


### PR DESCRIPTION
### 💡 개요
- #227 

### 📃 작업 내용
- 공동작업자 관련 API 연동

### 💻 구현 화면
코드로 합류 | 승인/거절 
:--: | :--:
<video src="https://github.com/user-attachments/assets/4fccd575-a56e-417c-ac8b-823e908c2137" width="300" /> | <video src="https://github.com/user-attachments/assets/dc4de653-7103-45d6-8dd2-8ead17e6cbd2" width="300" /> 

#### 합류한 티켓
<img src="https://github.com/user-attachments/assets/90a2647e-39f3-43c4-9c46-3c72306ab06a" width = "300" />

### 🎸 기타
- FriendViewModel refetch 실패 시 UiState.Error로 덮어쓰여서 화면이 빈 상태가 될 수 있습니다.
- 현재 api 응답값에 따른 toast를 ui에서 띄우기 위해서 route 단에서 설계 이후 boolean 값만 screen으로 넘겨주고 있습니다.