### PR TITLE
🔀 :: (#259) 생성 화면 수정

### DIFF
--- a/core/model/src/main/java/com/idiotfrogs/model/timecapsule/MyTimeCapsuleResponse.kt
+++ b/core/model/src/main/java/com/idiotfrogs/model/timecapsule/MyTimeCapsuleResponse.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 data class MyTimeCapsuleResponse(
     val timeCapsuleId: Long,
     val title: String,
-    val openedAt: LocalDateTime,
+    val openedAt: LocalDateTime?,
     val mainImageUrl: String,
     val timeCapsuleStatus: TimeCapsuleStatus,
     val role: TimeCapsuleRole

--- a/core/model/src/main/java/com/idiotfrogs/model/timecapsule/TimeCapsuleCreateRequest.kt
+++ b/core/model/src/main/java/com/idiotfrogs/model/timecapsule/TimeCapsuleCreateRequest.kt
@@ -1,11 +1,9 @@
 package com.idiotfrogs.model.timecapsule
 
-import kotlinx.datetime.LocalDateTime
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class TimeCapsuleCreateRequest(
     val title: String,
     val description: String?,
-    val openedAt: LocalDateTime
 )

--- a/core/model/src/main/java/com/idiotfrogs/model/timecapsule/TimeCapsuleCreateResponse.kt
+++ b/core/model/src/main/java/com/idiotfrogs/model/timecapsule/TimeCapsuleCreateResponse.kt
@@ -8,7 +8,7 @@ data class TimeCapsuleCreateResponse(
     val id: Long,
     val title: String,
     val description: String?,
-    val openedAt: LocalDateTime,
+    val openedAt: LocalDateTime?,
     val timeCapsuleStatus: String,
     val mainImageUrl: String
 )

--- a/core/model/src/main/java/com/idiotfrogs/model/timecapsule/TimeCapsuleResponse.kt
+++ b/core/model/src/main/java/com/idiotfrogs/model/timecapsule/TimeCapsuleResponse.kt
@@ -9,7 +9,7 @@ data class TimeCapsuleResponse(
     val description: String?,
     val buriedAt: LocalDateTime?,
     val createdAt: LocalDateTime,
-    val openedAt: LocalDateTime,
+    val openedAt: LocalDateTime?,
     val mainImageUrl: String,
     val timeCapsuleStatus: TimeCapsuleStatus,
     val userRole: TimeCapsuleRole,

--- a/feature/create/src/main/java/com/idiotfrogs/create/CreateScreen.kt
+++ b/feature/create/src/main/java/com/idiotfrogs/create/CreateScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,7 +30,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.idiotfrogs.designsystem.component.button.MSButton
-import com.idiotfrogs.designsystem.component.MSCalender
 import com.idiotfrogs.designsystem.component.MSText
 import com.idiotfrogs.designsystem.component.MSTextField
 import com.idiotfrogs.designsystem.component.MSDetailHeader
@@ -50,12 +47,8 @@ import com.idiotfrogs.navigation.Routes.*
 import com.idiotfrogs.resource.R
 import com.idiotfrogs.util.UiState
 import com.skydoves.landscapist.glide.GlideImage
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atTime
-import kotlinx.datetime.todayIn
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 @Composable
@@ -99,9 +92,6 @@ private fun CreateScreen(
     val scrollState = rememberScrollState()
     val (imageUri, launchImagePicker) = rememberPickerState()
     val isShowKeyboard = rememberKeyboardVisibility()
-
-    val today = Clock.System.todayIn(TimeZone.currentSystemDefault()).atTime(0, 0, 0, 0)
-    val selectedDate = remember { mutableStateOf(today) }
 
     val enabled = titleTextFieldState.text.isNotEmpty() && imageUri != null
 
@@ -194,17 +184,7 @@ private fun CreateScreen(
                     textFieldState = contentTextFieldState,
                     hint = "설명을 입력해주세요.",
                 )
-                Spacer(Modifier.height(16.dp))
-                MSText(
-                    modifier = Modifier.padding(start = 6.dp),
-                    text = "오픈 날짜",
-                    fontSize = 12.dp,
-                    fontWeight = FontWeight.Medium,
-                    color = MSTheme.color.greyG3
-                )
-                Spacer(Modifier.height(8.dp))
-                MSCalender { selectedDate.value = it }
-                Spacer(Modifier.height(24.dp))
+                Spacer(Modifier.height(14.dp))
             }
         }
         MSButton(
@@ -231,7 +211,6 @@ private fun CreateScreen(
                         CreateAction.CreateTimeCapsule(
                             titleTextFieldState.text.toString(),
                             contentTextFieldState.text.toString().takeIf { it.isNotEmpty() },
-                            selectedDate.value,
                             file
                         )
                     )

--- a/feature/create/src/main/java/com/idiotfrogs/create/CreateViewModel.kt
+++ b/feature/create/src/main/java/com/idiotfrogs/create/CreateViewModel.kt
@@ -23,7 +23,7 @@ class CreateViewModel @Inject constructor(
     override fun onAction(action: CreateAction) {
         when (action) {
             is CreateAction.CreateTimeCapsule -> createTimeCapsule(
-                action.title, action.description, action.openedAt, action.mainImage
+                action.title, action.description, action.mainImage
             )
             CreateAction.NavigateToBack -> intent { postSideEffect(CreateSideEffect.NavigateToBack) }
         }
@@ -32,14 +32,12 @@ class CreateViewModel @Inject constructor(
     private fun createTimeCapsule(
         title: String,
         description: String?,
-        openedAt: LocalDateTime,
         mainImage: File
     ) {
         safeLaunch {
             val request = TimeCapsuleCreateRequest(
                 title = title,
                 description = description,
-                openedAt = openedAt
             )
             val result = createTimeCapsuleUseCase(request, mainImage)
 
@@ -57,7 +55,6 @@ sealed interface CreateAction {
     data class CreateTimeCapsule(
         val title: String,
         val description: String?,
-        val openedAt: LocalDateTime,
         val mainImage: File
     ) : CreateAction
 


### PR DESCRIPTION
### 💡 개요
- #259 

### 📃 작업 내용
- 생성 화면 UI 수정 (캘린더 제거)
- 생성 API 수정
- openedAt nullable 처리

### 💻 구현 화면
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/user-attachments/assets/1a84a372-ed60-4fb2-b336-85c387764ca7" width="300" />

### 🎸 기타
- 현재 PR 머지 이후 #254 작업에서 이어서 홈 작업 진행될 예정입니다.