### PR TITLE
🔀 :: (#263) Wavy 관련 작업

### DIFF
--- a/core/designsystem/src/main/java/com/idiotfrogs/designsystem/util/WavyStroke.kt
+++ b/core/designsystem/src/main/java/com/idiotfrogs/designsystem/util/WavyStroke.kt
@@ -24,6 +24,8 @@ import kotlin.math.sin
 
 enum class DrawType { TOP, BOTTOM, START, END, ALL }
 
+enum class WavyAlign { INNER, OUTER }
+
 fun Modifier.wavyStroke(
     color: Color,
     drawType: DrawType = DrawType.ALL,
@@ -127,6 +129,7 @@ fun Modifier.wavyStroke(
 fun Modifier.wavyBackground(
     color: Color,
     drawType: DrawType = DrawType.ALL,
+    wavyAlign: WavyAlign = WavyAlign.INNER,
     strokeWidth: Dp = 3.dp,
     cornerRadius: Dp = 12.dp,
     amplitude: Dp = 2.dp,
@@ -182,6 +185,7 @@ fun Modifier.wavyBackground(
                     amplitude = ampPx,
                     seed = seed,
                     strokeWidth = strokePx,
+                    align = wavyAlign
                 )
             }
 
@@ -429,8 +433,10 @@ private fun makeEdgeWavyBackgroundPath(
     amplitude: Float,
     seed: Long,
     strokeWidth: Float,
+    align: WavyAlign
 ): WavyBackgroundPath {
-    val inset = amplitude + strokeWidth / 2f
+    val alignedAmplitude = if (align == WavyAlign.INNER) amplitude else -amplitude
+    val inset = alignedAmplitude + strokeWidth / 2f
 
     val count = when (edge) {
         DrawType.TOP,

--- a/core/designsystem/src/main/java/com/idiotfrogs/designsystem/util/WavyStroke.kt
+++ b/core/designsystem/src/main/java/com/idiotfrogs/designsystem/util/WavyStroke.kt
@@ -24,8 +24,6 @@ import kotlin.math.sin
 
 enum class DrawType { TOP, BOTTOM, START, END, ALL }
 
-enum class WavyAlign { INNER, OUTER }
-
 fun Modifier.wavyStroke(
     color: Color,
     drawType: DrawType = DrawType.ALL,
@@ -99,13 +97,44 @@ fun Modifier.wavyStroke(
                 }
             }
 
+            val fillPath = if (drawType == DrawType.ALL) {
+                path // ALL은 이미 닫힌 Path 이다
+            } else {
+                Path().apply {
+                    addPath(path)
+                    when (drawType) {
+                        DrawType.TOP -> {
+                            lineTo(size.width, size.height)
+                            lineTo(0f, size.height)
+                            lineTo(0f, 0f)
+                        }
+                        DrawType.BOTTOM -> {
+                            lineTo(size.width, 0f)
+                            lineTo(0f, 0f)
+                            lineTo(0f, size.height)
+                        }
+                        DrawType.START -> {
+                            lineTo(size.width, size.height)
+                            lineTo(size.width, 0f)
+                            lineTo(0f, 0f)
+                        }
+                        DrawType.END -> {
+                            lineTo(0f, size.height)
+                            lineTo(0f, 0f)
+                            lineTo(size.width, 0f)
+                        }
+                    }
+                    close()
+                }
+            }
+
             onDrawWithContent {
                 fillColor?.let {
-                    drawPath(path = path, color = it)
+                    drawPath(path = fillPath, color = it)
                 }
 
                 if (clipContent) {
-                    clipPath(path) {
+                    clipPath(fillPath) {
                         this@onDrawWithContent.drawContent()
                     }
                 } else {
@@ -126,100 +155,8 @@ fun Modifier.wavyStroke(
         .padding(contentPadding)
 )
 
-fun Modifier.wavyBackground(
-    color: Color,
-    drawType: DrawType = DrawType.ALL,
-    wavyAlign: WavyAlign = WavyAlign.INNER,
-    strokeWidth: Dp = 3.dp,
-    cornerRadius: Dp = 12.dp,
-    amplitude: Dp = 2.dp,
-    spacing: Dp = 6.dp,
-    seed: Long = 0xC0FFEE_BABEL,
-    fillColor: Color = color,
-    contentPadding: Dp = 0.dp,
-    clipContent: Boolean = false,
-): Modifier = this.then(
-    Modifier
-        .drawWithCache {
-            val strokePx = strokeWidth.toPx()
-            val ampPx = amplitude.toPx()
-            val spacingPx = spacing.toPx().coerceAtLeast(1f)
-
-            val pathInset = ampPx + strokePx / 2f
-
-            val rect = Rect(
-                left = pathInset,
-                top = pathInset,
-                right = size.width - pathInset,
-                bottom = size.height - pathInset,
-            )
-
-            val radius = (cornerRadius.toPx() - pathInset)
-                .coerceAtLeast(0f)
-                .coerceAtMost(min(rect.width, rect.height) / 2f)
-
-            val paths = when (drawType) {
-                DrawType.ALL -> {
-                    val path = makeWavyPath(
-                        rect = rect,
-                        cornerRadius = radius,
-                        spacing = spacingPx,
-                        amplitude = ampPx,
-                        seed = seed,
-                    )
-
-                    WavyBackgroundPath(
-                        fillPath = path,
-                        strokePath = path,
-                    )
-                }
-
-                DrawType.TOP,
-                DrawType.BOTTOM,
-                DrawType.START,
-                DrawType.END -> makeEdgeWavyBackgroundPath(
-                    width = size.width,
-                    height = size.height,
-                    edge = drawType,
-                    spacing = spacingPx,
-                    amplitude = ampPx,
-                    seed = seed,
-                    strokeWidth = strokePx,
-                    align = wavyAlign
-                )
-            }
-
-            onDrawWithContent {
-                drawPath(
-                    path = paths.fillPath,
-                    color = fillColor,
-                )
-
-                if (clipContent) {
-                    clipPath(paths.fillPath) {
-                        this@onDrawWithContent.drawContent()
-                    }
-                } else {
-                    drawContent()
-                }
-
-                drawPath(
-                    path = paths.strokePath,
-                    color = color,
-                    style = Stroke(
-                        width = strokePx,
-                        cap = StrokeCap.Round,
-                        join = StrokeJoin.Round,
-                    ),
-                )
-            }
-        }
-        .padding(contentPadding)
-)
 
 private data class WavyData(val point: Offset, val normal: Offset)
-
-private data class WavyBackgroundPath(val fillPath: Path, val strokePath: Path)
 
 private fun makeWavyPath(
     rect: Rect,
@@ -424,128 +361,3 @@ private fun makeSingleAxisWavyPath(
 
 private fun midpoint(a: Offset, b: Offset): Offset =
     Offset((a.x + b.x) / 2f, (a.y + b.y) / 2f)
-
-private fun makeEdgeWavyBackgroundPath(
-    width: Float,
-    height: Float,
-    edge: DrawType,
-    spacing: Float,
-    amplitude: Float,
-    seed: Long,
-    strokeWidth: Float,
-    align: WavyAlign
-): WavyBackgroundPath {
-    val alignedAmplitude = if (align == WavyAlign.INNER) amplitude else -amplitude
-    val inset = alignedAmplitude + strokeWidth / 2f
-
-    val count = when (edge) {
-        DrawType.TOP,
-        DrawType.BOTTOM -> max(1, (width / spacing).toInt())
-
-        DrawType.START,
-        DrawType.END -> max(1, (height / spacing).toInt())
-
-        DrawType.ALL -> 1
-    }
-
-    var nextSeed = seed
-
-    val points = buildList {
-        repeat(count + 1) { i ->
-            val t = i / count.toFloat()
-
-            nextSeed = nextSeed * 6364136223846793005L + 1442695040888963407L
-            val random = ((nextSeed ushr 1) % 2000L) / 1000f - 1f
-            val offset = random * amplitude
-
-            add(
-                when (edge) {
-                    DrawType.TOP -> Offset(
-                        x = width * t,
-                        y = inset + offset,
-                    )
-
-                    DrawType.BOTTOM -> Offset(
-                        x = width * t,
-                        y = height - inset + offset,
-                    )
-
-                    DrawType.START -> Offset(
-                        x = inset + offset,
-                        y = height * t,
-                    )
-
-                    DrawType.END -> Offset(
-                        x = width - inset + offset,
-                        y = height * t,
-                    )
-
-                    DrawType.ALL -> Offset.Zero
-                }
-            )
-        }
-    }
-
-    val strokePath = makeOpenSmoothPath(points)
-
-    val fillPath = Path().apply {
-        val first = points.first()
-        moveTo(first.x, first.y)
-
-        points.zipWithNext { current, next ->
-            val mid = midpoint(current, next)
-            quadraticTo(current.x, current.y, mid.x, mid.y)
-        }
-
-        val last = points.last()
-        lineTo(last.x, last.y)
-
-        when (edge) {
-            DrawType.TOP -> {
-                lineTo(width, height)
-                lineTo(0f, height)
-            }
-
-            DrawType.BOTTOM -> {
-                lineTo(width, 0f)
-                lineTo(0f, 0f)
-            }
-
-            DrawType.START -> {
-                lineTo(width, height)
-                lineTo(width, 0f)
-            }
-
-            DrawType.END -> {
-                lineTo(0f, height)
-                lineTo(0f, 0f)
-            }
-
-            DrawType.ALL -> Unit
-        }
-
-        close()
-    }
-
-    return WavyBackgroundPath(
-        fillPath = fillPath,
-        strokePath = strokePath,
-    )
-}
-
-private fun makeOpenSmoothPath(points: List<Offset>): Path {
-    return Path().apply {
-        if (points.isEmpty()) return@apply
-
-        val first = points.first()
-        moveTo(first.x, first.y)
-
-        points.zipWithNext { current, next ->
-            val mid = midpoint(current, next)
-            quadraticTo(current.x, current.y, mid.x, mid.y)
-        }
-
-        val last = points.last()
-        lineTo(last.x, last.y)
-    }
-}

--- a/core/designsystem/src/main/java/com/idiotfrogs/designsystem/util/WavyStroke.kt
+++ b/core/designsystem/src/main/java/com/idiotfrogs/designsystem/util/WavyStroke.kt
@@ -23,6 +23,7 @@ import kotlin.math.roundToInt
 import kotlin.math.sin
 
 enum class DrawType { TOP, BOTTOM, START, END, ALL }
+enum class WavyAlign { INNER, OUTER }
 
 fun Modifier.wavyStroke(
     color: Color,
@@ -35,6 +36,7 @@ fun Modifier.wavyStroke(
     fillColor: Color? = null,
     contentPadding: Dp = 0.dp,
     clipContent: Boolean = false,
+    wavyAlign: WavyAlign = WavyAlign.INNER,
 ): Modifier = this.then(
     Modifier
         .drawWithCache {
@@ -43,17 +45,22 @@ fun Modifier.wavyStroke(
             val spacingPx = spacing.toPx().coerceAtLeast(1f)
 
             val pathInset = ampPx + strokePx / 2f
+            val signedInset = if (wavyAlign == WavyAlign.INNER) pathInset else -pathInset
 
             val rect = Rect(
-                left = pathInset,
-                top = pathInset,
-                right = size.width - pathInset,
-                bottom = size.height - pathInset,
+                left = signedInset,
+                top = signedInset,
+                right = size.width - signedInset,
+                bottom = size.height - signedInset,
             )
 
-            val radius = (cornerRadius.toPx() - pathInset)
-                .coerceAtLeast(0f)
-                .coerceAtMost(min(rect.width, rect.height) / 2f)
+            val radius = if (wavyAlign == WavyAlign.INNER) {
+                (cornerRadius.toPx() - pathInset)
+                    .coerceAtLeast(0f)
+                    .coerceAtMost(min(rect.width, rect.height) / 2f)
+            } else {
+                cornerRadius.toPx() + pathInset // 바깥 사각형이 커지므로 모서리도 키움
+            }
 
             val path = when (drawType) {
                 DrawType.TOP -> makeTopWavyPath(

--- a/feature/create/src/main/java/com/idiotfrogs/create/CreateScreen.kt
+++ b/feature/create/src/main/java/com/idiotfrogs/create/CreateScreen.kt
@@ -192,10 +192,9 @@ private fun CreateScreen(
                 .fillMaxWidth()
                 .height(48.dp)
                 .padding(horizontal = buttonHorizontalPadding)
-                .wavyBackground(
+                .wavyStroke(
                     color = if (enabled) MSTheme.color.primaryNormal else MSTheme.color.primaryLight,
                     drawType = if (isShowKeyboard) DrawType.TOP else DrawType.ALL,
-                    contentPadding = if (isShowKeyboard) 0.dp else 5.dp,
                     clipContent = true,
                 ),
             enabled = enabled,

--- a/feature/create/src/main/java/com/idiotfrogs/create/CreateScreen.kt
+++ b/feature/create/src/main/java/com/idiotfrogs/create/CreateScreen.kt
@@ -39,7 +39,6 @@ import com.idiotfrogs.designsystem.util.keyboardAutoScroll
 import com.idiotfrogs.designsystem.util.noRippleClickable
 import com.idiotfrogs.designsystem.util.rememberKeyboardVisibility
 import com.idiotfrogs.designsystem.util.rememberPickerState
-import com.idiotfrogs.designsystem.util.wavyBackground
 import com.idiotfrogs.designsystem.util.wavyStroke
 import com.idiotfrogs.extension.toFile
 import com.idiotfrogs.navigation.LocalComposeMSNavigator

--- a/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
@@ -201,7 +201,7 @@ fun DetailScreen(
                 .fillMaxSize()
                 .hazeSource(hazeState)
                 .navigationBarsPadding()
-                .background(MSTheme.color.bgNormal)
+                .background(Color.White)
                 .verticalScroll(scrollState),
         ) {
         Box(

--- a/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
@@ -55,9 +55,7 @@ import com.idiotfrogs.designsystem.theme.MSTheme
 import com.idiotfrogs.designsystem.util.DrawType
 import com.idiotfrogs.designsystem.util.WavyAlign
 import com.idiotfrogs.designsystem.util.noRippleClickable
-import com.idiotfrogs.designsystem.util.wavyBackground
 import com.idiotfrogs.designsystem.util.wavyStroke
-import com.idiotfrogs.extension.toDday
 import com.idiotfrogs.extension.toOpenRemainingText
 import com.idiotfrogs.extension.toYearMonthDayWeek
 import com.idiotfrogs.model.timecapsule.TimeCapsuleRole
@@ -216,6 +214,7 @@ fun DetailScreen(
                     amplitude = 2.dp,
                     spacing = 3.dp,
                     clipContent = true,
+                    wavyAlign = WavyAlign.OUTER
                 )
         ) {
             capsule?.mainImageUrl?.let {

--- a/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
@@ -53,6 +53,7 @@ import com.idiotfrogs.designsystem.component.MSToast
 import com.idiotfrogs.designsystem.component.button.MSButton
 import com.idiotfrogs.designsystem.theme.MSTheme
 import com.idiotfrogs.designsystem.util.DrawType
+import com.idiotfrogs.designsystem.util.WavyAlign
 import com.idiotfrogs.designsystem.util.noRippleClickable
 import com.idiotfrogs.designsystem.util.wavyBackground
 import com.idiotfrogs.designsystem.util.wavyStroke
@@ -208,7 +209,7 @@ fun DetailScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(420.dp)
-                .wavyBackground(
+                .wavyStroke(
                     color = Color.Black,
                     drawType = DrawType.BOTTOM,
                     strokeWidth = 5.dp,
@@ -260,7 +261,6 @@ fun DetailScreen(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MSTheme.color.white)
                 .padding(horizontal = 20.dp, vertical = 24.dp)
         ) {
             if (isBuried) {


### PR DESCRIPTION
### 💡 개요
- #263 

### 📃 작업 내용
- 회색 선 노출되는 부분 수정
- 기준선 내부가 아닌 외곽쪽에 선 그리는 로직 추

### 💻 구현 화면
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/c1aac8dc-6150-4200-a9a4-8b1050e6ef1f" width="300" /> | <img src="https://github.com/user-attachments/assets/52a69f26-d052-44eb-909e-62e9009b4161" width="300" />

### 🎸 기타
- 구현 화면의 After쪽은 외곽이랑 회색 선 삭제가 둘 다 적용된 버전입니다.
- 실제 디테일쪽에 외곽을 변경하지는 않았으며 예시를 위해 캡쳐할 때만 수정 후 캡쳐했습니다.