### PR TITLE
🔀 :: (#273) 메시지 화면 API 연동

### DIFF
--- a/core/model/src/main/java/com/idiotfrogs/model/timecapsule/TimeCapsuleContentResponse.kt
+++ b/core/model/src/main/java/com/idiotfrogs/model/timecapsule/TimeCapsuleContentResponse.kt
@@ -1,0 +1,18 @@
+package com.idiotfrogs.model.timecapsule
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TimeCapsuleContentResponse(
+    val userId: Long,
+    val nickname: String,
+    val profileImageUrl: String,
+    val capsuleContents: List<CapsuleContentsData>,
+)
+
+@Serializable
+data class CapsuleContentsData(
+    val contentId: Long,
+    val content: String?,
+    val attachedFileUrls: List<String>?,
+)

--- a/core/network/src/main/java/com/idiotfrogs/network/service/TimeCapsuleService.kt
+++ b/core/network/src/main/java/com/idiotfrogs/network/service/TimeCapsuleService.kt
@@ -1,15 +1,18 @@
 package com.idiotfrogs.network.service
 
 import com.idiotfrogs.model.timecapsule.BuryTimeCapsuleRequest
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
 import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
 import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
+import com.idiotfrogs.model.timecapsule.TimeCapsuleContentResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleInviteCodeResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleResponse
 import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -87,4 +90,27 @@ interface TimeCapsuleService {
     suspend fun leaveTimeCapsule(
         @Path("capsuleId") capsuleId: Long
     )
+
+    @GET("api/time-capsule-content/{timeCapsuleId}/contents")
+    suspend fun getTimeCapsuleContent(@Path("timeCapsuleId") timeCapsuleId: Long): List<TimeCapsuleContentResponse>
+
+    @GET("api/time-capsule-content/{timeCapsuleId}/my-contents")
+    suspend fun getMyTimeCapsuleContent(@Path("timeCapsuleId") timeCapsuleId: Long): List<CapsuleContentsData>
+
+    @POST("api/time-capsule-content/{timeCapsuleId}")
+    @Multipart
+    suspend fun createTimeCapsuleContent(
+        @Path("timeCapsuleId") timeCapsuleId: Long,
+        @Part("content") content: RequestBody,
+        @Part files: List<MultipartBody.Part>,
+    ): CapsuleContentsData
+
+    @PUT("api/time-capsule-content/{contentId}")
+    suspend fun modifyTimeCapsuleContent(
+        @Path("contentId") contentId: Long,
+        @Query("content") content: String,
+    ): CapsuleContentsData
+
+    @DELETE("api/time-capsule-content")
+    suspend fun deleteTimeCapsuleContent(@Query("contentIds") contentIds: List<Long>)
 }

--- a/data/src/main/java/com/idiotfrogs/data/datasource/timecapsule/TimeCapsuleDataSource.kt
+++ b/data/src/main/java/com/idiotfrogs/data/datasource/timecapsule/TimeCapsuleDataSource.kt
@@ -1,15 +1,18 @@
 package com.idiotfrogs.data.datasource.timecapsule
 
 import com.idiotfrogs.model.timecapsule.BuryTimeCapsuleRequest
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
 import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
 import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
+import com.idiotfrogs.model.timecapsule.TimeCapsuleContentResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleInviteCodeResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleResponse
 import okhttp3.MultipartBody
+import okhttp3.RequestBody
 
 interface TimeCapsuleDataSource {
     suspend fun createTimeCapsule(
@@ -58,4 +61,21 @@ interface TimeCapsuleDataSource {
     ): TimeCapsuleCollaboratorsResponse
 
     suspend fun leaveTimeCapsule(capsuleId: Long)
+
+    suspend fun getTimeCapsuleContent(timeCapsuleId: Long): List<TimeCapsuleContentResponse>
+
+    suspend fun getMyTimeCapsuleContent(timeCapsuleId: Long): List<CapsuleContentsData>
+
+    suspend fun createTimeCapsuleContent(
+        timeCapsuleId: Long,
+        content: RequestBody,
+        files: List<MultipartBody.Part>,
+    ): CapsuleContentsData
+
+    suspend fun modifyTimeCapsuleContent(
+        contentId: Long,
+        content: String,
+    ): CapsuleContentsData
+
+    suspend fun deleteTimeCapsuleContent(contentIds: List<Long>)
 }

--- a/data/src/main/java/com/idiotfrogs/data/datasource/timecapsule/TimeCapsuleDataSourceImpl.kt
+++ b/data/src/main/java/com/idiotfrogs/data/datasource/timecapsule/TimeCapsuleDataSourceImpl.kt
@@ -1,16 +1,19 @@
 package com.idiotfrogs.data.datasource.timecapsule
 
 import com.idiotfrogs.model.timecapsule.BuryTimeCapsuleRequest
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
 import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
 import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
+import com.idiotfrogs.model.timecapsule.TimeCapsuleContentResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleInviteCodeResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleResponse
 import com.idiotfrogs.network.service.TimeCapsuleService
 import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import javax.inject.Inject
 
 class TimeCapsuleDataSourceImpl @Inject constructor(
@@ -95,5 +98,39 @@ class TimeCapsuleDataSourceImpl @Inject constructor(
 
     override suspend fun leaveTimeCapsule(capsuleId: Long) {
         return timeCapsuleService.leaveTimeCapsule(capsuleId)
+    }
+
+    override suspend fun getTimeCapsuleContent(timeCapsuleId: Long): List<TimeCapsuleContentResponse> {
+        return timeCapsuleService.getTimeCapsuleContent(timeCapsuleId)
+    }
+
+    override suspend fun getMyTimeCapsuleContent(timeCapsuleId: Long): List<CapsuleContentsData> {
+        return timeCapsuleService.getMyTimeCapsuleContent(timeCapsuleId)
+    }
+
+    override suspend fun createTimeCapsuleContent(
+        timeCapsuleId: Long,
+        content: RequestBody,
+        files: List<MultipartBody.Part>
+    ): CapsuleContentsData {
+        return timeCapsuleService.createTimeCapsuleContent(
+            timeCapsuleId = timeCapsuleId,
+            content = content,
+            files = files
+        )
+    }
+
+    override suspend fun modifyTimeCapsuleContent(
+        contentId: Long,
+        content: String
+    ): CapsuleContentsData {
+        return timeCapsuleService.modifyTimeCapsuleContent(
+            contentId = contentId,
+            content = content
+        )
+    }
+
+    override suspend fun deleteTimeCapsuleContent(contentIds: List<Long>) {
+        return timeCapsuleService.deleteTimeCapsuleContent(contentIds)
     }
 }

--- a/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepository.kt
+++ b/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepository.kt
@@ -1,14 +1,17 @@
 package com.idiotfrogs.data.repository.timecapsule
 
 import com.idiotfrogs.model.timecapsule.BuryTimeCapsuleRequest
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
 import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
 import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
+import com.idiotfrogs.model.timecapsule.TimeCapsuleContentResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleInviteCodeResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleResponse
+import okhttp3.MultipartBody
 import java.io.File
 
 interface TimeCapsuleRepository {
@@ -58,4 +61,21 @@ interface TimeCapsuleRepository {
     ): TimeCapsuleCollaboratorsResponse
 
     suspend fun leaveTimeCapsule(capsuleId: Long)
+
+    suspend fun getTimeCapsuleContent(timeCapsuleId: Long): List<TimeCapsuleContentResponse>
+
+    suspend fun getMyTimeCapsuleContent(timeCapsuleId: Long): List<CapsuleContentsData>
+
+    suspend fun createTimeCapsuleContent(
+        timeCapsuleId: Long,
+        content: String,
+        files: List<File>,
+    ): CapsuleContentsData
+
+    suspend fun modifyTimeCapsuleContent(
+        contentId: Long,
+        content: String,
+    ): CapsuleContentsData
+
+    suspend fun deleteTimeCapsuleContent(contentIds: List<Long>)
 }

--- a/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepositoryImpl.kt
+++ b/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepositoryImpl.kt
@@ -2,10 +2,12 @@ package com.idiotfrogs.data.repository.timecapsule
 
 import com.idiotfrogs.data.datasource.timecapsule.TimeCapsuleDataSource
 import com.idiotfrogs.model.timecapsule.BuryTimeCapsuleRequest
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
 import com.idiotfrogs.model.timecapsule.MyTimeCapsuleResponse
 import com.idiotfrogs.model.timecapsule.PendingCollaboratorsRequest
 import com.idiotfrogs.model.timecapsule.ProcessCollaboratorRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCollaboratorsResponse
+import com.idiotfrogs.model.timecapsule.TimeCapsuleContentResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleInviteCodeResponse
@@ -13,6 +15,7 @@ import com.idiotfrogs.model.timecapsule.TimeCapsuleResponse
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.File
 import javax.inject.Inject
 
@@ -100,5 +103,45 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
 
     override suspend fun leaveTimeCapsule(capsuleId: Long) {
         return timeCapsuleDataSource.leaveTimeCapsule(capsuleId)
+    }
+
+    override suspend fun getTimeCapsuleContent(timeCapsuleId: Long): List<TimeCapsuleContentResponse> {
+        return timeCapsuleDataSource.getTimeCapsuleContent(timeCapsuleId)
+    }
+
+    override suspend fun getMyTimeCapsuleContent(timeCapsuleId: Long): List<CapsuleContentsData> {
+        return timeCapsuleDataSource.getMyTimeCapsuleContent(timeCapsuleId)
+    }
+
+    override suspend fun createTimeCapsuleContent(
+        timeCapsuleId: Long,
+        content: String,
+        files: List<File>
+    ): CapsuleContentsData {
+        val contentBody = content.toRequestBody("text/plain".toMediaType())
+        val fileParts = files.map {
+            val requestBody = it.asRequestBody("image/jpeg".toMediaType())
+            MultipartBody.Part.createFormData("files", it.name, requestBody)
+        }
+
+        return timeCapsuleDataSource.createTimeCapsuleContent(
+            timeCapsuleId = timeCapsuleId,
+            content = contentBody,
+            files = fileParts
+        )
+    }
+
+    override suspend fun modifyTimeCapsuleContent(
+        contentId: Long,
+        content: String
+    ): CapsuleContentsData {
+        return timeCapsuleDataSource.modifyTimeCapsuleContent(
+            contentId = contentId,
+            content = content
+        )
+    }
+
+    override suspend fun deleteTimeCapsuleContent(contentIds: List<Long>) {
+        return timeCapsuleDataSource.deleteTimeCapsuleContent(contentIds)
     }
 }

--- a/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/CreateTimeCapsuleContentUseCase.kt
+++ b/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/CreateTimeCapsuleContentUseCase.kt
@@ -1,0 +1,23 @@
+package com.idiotfrogs.domain.usecase.timecapsule
+
+import com.idiotfrogs.data.repository.timecapsule.TimeCapsuleRepository
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
+import com.idiotfrogs.util.safeCatching
+import java.io.File
+import javax.inject.Inject
+
+class CreateTimeCapsuleContentUseCase @Inject constructor(
+    private val timeCapsuleRepository: TimeCapsuleRepository
+) {
+    suspend operator fun invoke(
+        timeCapsuleId: Long,
+        content: String,
+        files: List<File>,
+    ): Result<CapsuleContentsData> = safeCatching {
+        timeCapsuleRepository.createTimeCapsuleContent(
+            timeCapsuleId = timeCapsuleId,
+            content = content,
+            files = files
+        )
+    }
+}

--- a/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/DeleteTimeCapsuleContentUseCase.kt
+++ b/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/DeleteTimeCapsuleContentUseCase.kt
@@ -1,0 +1,13 @@
+package com.idiotfrogs.domain.usecase.timecapsule
+
+import com.idiotfrogs.data.repository.timecapsule.TimeCapsuleRepository
+import com.idiotfrogs.util.safeCatching
+import javax.inject.Inject
+
+class DeleteTimeCapsuleContentUseCase @Inject constructor(
+    private val timeCapsuleRepository: TimeCapsuleRepository
+) {
+    suspend operator fun invoke(contentIds: List<Long>): Result<Unit> = safeCatching {
+        timeCapsuleRepository.deleteTimeCapsuleContent(contentIds)
+    }
+}

--- a/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/GetMyTimeCapsuleContentUseCase.kt
+++ b/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/GetMyTimeCapsuleContentUseCase.kt
@@ -1,0 +1,14 @@
+package com.idiotfrogs.domain.usecase.timecapsule
+
+import com.idiotfrogs.data.repository.timecapsule.TimeCapsuleRepository
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
+import com.idiotfrogs.util.safeCatching
+import javax.inject.Inject
+
+class GetMyTimeCapsuleContentUseCase @Inject constructor(
+    private val timeCapsuleRepository: TimeCapsuleRepository
+) {
+    suspend operator fun invoke(timeCapsuleId: Long): Result<List<CapsuleContentsData>> = safeCatching {
+        timeCapsuleRepository.getMyTimeCapsuleContent(timeCapsuleId)
+    }
+}

--- a/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/GetTimeCapsuleContentUseCase.kt
+++ b/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/GetTimeCapsuleContentUseCase.kt
@@ -1,0 +1,14 @@
+package com.idiotfrogs.domain.usecase.timecapsule
+
+import com.idiotfrogs.data.repository.timecapsule.TimeCapsuleRepository
+import com.idiotfrogs.model.timecapsule.TimeCapsuleContentResponse
+import com.idiotfrogs.util.safeCatching
+import javax.inject.Inject
+
+class GetTimeCapsuleContentUseCase @Inject constructor(
+    private val timeCapsuleRepository: TimeCapsuleRepository
+) {
+    suspend operator fun invoke(timeCapsuleId: Long): Result<List<TimeCapsuleContentResponse>> = safeCatching {
+        timeCapsuleRepository.getTimeCapsuleContent(timeCapsuleId)
+    }
+}

--- a/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/ModifyTimeCapsuleContentUseCase.kt
+++ b/domain/src/main/java/com/idiotfrogs/domain/usecase/timecapsule/ModifyTimeCapsuleContentUseCase.kt
@@ -1,0 +1,20 @@
+package com.idiotfrogs.domain.usecase.timecapsule
+
+import com.idiotfrogs.data.repository.timecapsule.TimeCapsuleRepository
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
+import com.idiotfrogs.util.safeCatching
+import javax.inject.Inject
+
+class ModifyTimeCapsuleContentUseCase @Inject constructor(
+    private val timeCapsuleRepository: TimeCapsuleRepository
+) {
+    suspend operator fun invoke(
+        contentId: Long,
+        content: String,
+    ): Result<CapsuleContentsData> = safeCatching {
+        timeCapsuleRepository.modifyTimeCapsuleContent(
+            contentId = contentId,
+            content = content
+        )
+    }
+}

--- a/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
@@ -473,7 +473,7 @@ fun DetailScreen(
                     )
                     Spacer(Modifier.height(4.dp))
                     MSText(
-                        text = "2개 등록",
+                        text = "${capsule?.myContentCount}개 등록",
                         fontSize = 12.dp,
                         fontWeight = FontWeight.Medium,
                         color = MSTheme.color.primaryDark,
@@ -497,7 +497,7 @@ fun DetailScreen(
                     )
                     Spacer(Modifier.height(4.dp))
                     MSText(
-                        text = "12개 등록",
+                        text = "${capsule?.myImageCount}개 등록",
                         fontSize = 12.dp,
                         fontWeight = FontWeight.Medium,
                         color = MSTheme.color.primaryDark,

--- a/feature/message/src/main/java/com/idiotfrogs/message/MessageScreen.kt
+++ b/feature/message/src/main/java/com/idiotfrogs/message/MessageScreen.kt
@@ -93,7 +93,6 @@ fun MessageRoute(
         UiState.Init -> Unit
         is UiState.Success -> {
             MessageScreen(
-                capsuleId = capsuleId,
                 data = state.data,
                 onAction = viewModel::onAction,
             )
@@ -104,7 +103,6 @@ fun MessageRoute(
 
 @Composable
 fun MessageScreen(
-    capsuleId: Long,
     data: MessageData,
     onAction: (MessageAction) -> Unit,
     modifier: Modifier = Modifier,
@@ -660,7 +658,6 @@ private fun Set<String>.toggle(id: String): Set<String> =
 @Composable
 fun MessageScreenPreview() {
     MessageScreen(
-        capsuleId = 0L,
         data = MessageData(),
         onAction = {},
     )

--- a/feature/message/src/main/java/com/idiotfrogs/message/MessageScreen.kt
+++ b/feature/message/src/main/java/com/idiotfrogs/message/MessageScreen.kt
@@ -1,6 +1,5 @@
 package com.idiotfrogs.message
 
-import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -47,6 +46,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
@@ -64,6 +64,7 @@ import com.idiotfrogs.designsystem.theme.MSTheme
 import com.idiotfrogs.designsystem.util.noRippleClickable
 import com.idiotfrogs.designsystem.util.rememberMultiPickerState
 import com.idiotfrogs.designsystem.util.wavyStroke
+import com.idiotfrogs.extension.toFile
 import com.idiotfrogs.message.component.MessageCheckBox
 import com.idiotfrogs.message.component.MessagePreviewBanner
 import com.idiotfrogs.message.component.MessageSettingListItem
@@ -77,7 +78,7 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 @Composable
 fun MessageRoute(
     capsuleId: Long,
-    viewModel: MessageViewModel = hiltViewModel(),
+    viewModel: MessageViewModel = hiltViewModel<MessageViewModel, MessageViewModel.Factory>(key = capsuleId.toString()) { it.create(capsuleId) },
 ) {
     val navigator = LocalComposeMSNavigator.current
     val uiState by viewModel.collectAsState()
@@ -88,11 +89,12 @@ fun MessageRoute(
         }
     }
 
-    when (uiState) {
+    when (val state = uiState) {
         UiState.Init -> Unit
         is UiState.Success -> {
             MessageScreen(
                 capsuleId = capsuleId,
+                data = state.data,
                 onAction = viewModel::onAction,
             )
         }
@@ -103,15 +105,17 @@ fun MessageRoute(
 @Composable
 fun MessageScreen(
     capsuleId: Long,
+    data: MessageData,
     onAction: (MessageAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
     var currentTab by remember { mutableStateOf(MessageTab.MESSAGE) }
     var isDeleteMode by rememberSaveable { mutableStateOf(false) }
     var showMessageInput by rememberSaveable { mutableStateOf(false) }
     var activeMessageId by rememberSaveable { mutableStateOf<Long?>(null) }
     var messageItems by remember { mutableStateOf(emptyList<MessageListItemUiModel>()) }
-    var selectedIds by rememberSaveable { mutableStateOf(emptySet<Long>()) }
+    var selectedIds by rememberSaveable { mutableStateOf(emptySet<String>()) }
     var photoItems by remember { mutableStateOf(emptyList<PhotoListItemUiModel>()) }
 
     val messageTextFieldState = rememberTextFieldState()
@@ -121,7 +125,36 @@ fun MessageScreen(
     val (pickedPhotoUris, launchPhotoPicker) = rememberMultiPickerState()
     val pagerState = rememberPagerState { MessageTab.entries.size }
     val canDelete = selectedIds.isNotEmpty()
-    val activeMessageItem = messageItems.firstOrNull { it.id == activeMessageId }
+    val activeMessageItem = messageItems.firstOrNull { it.contentId == activeMessageId }
+
+    LaunchedEffect(data.contents) {
+        messageItems = data.contents
+            .filter { !it.content.isNullOrBlank() }
+            .mapIndexed { index, item ->
+                MessageListItemUiModel(
+                    id = "message-${item.contentId}",
+                    contentId = item.contentId,
+                    title = "${MessageTab.MESSAGE.title} ${index + 1}",
+                    description = item.content.orEmpty(),
+                )
+            }
+
+        photoItems = data.contents
+            .flatMap { content ->
+                content.attachedFileUrls.orEmpty().mapIndexed { index, imageUrl ->
+                    PhotoListItemUiModel(
+                        id = "photo-${content.contentId}-$index",
+                        contentId = content.contentId,
+                        imageModel = imageUrl,
+                    )
+                }
+            }
+
+        isDeleteMode = false
+        showMessageInput = false
+        activeMessageId = null
+        selectedIds = emptySet()
+    }
 
     fun closeMessageInput() {
         showMessageInput = false
@@ -136,21 +169,19 @@ fun MessageScreen(
 
         if (message.isBlank()) return
 
-        if (activeMessageId == null) {
-            messageItems = messageItems + MessageListItemUiModel(
-                id = (messageItems.maxOfOrNull { it.id } ?: 0L) + 1L,
-                title = "메시지 ${messageItems.size + 1}",
-                description = message,
+        activeMessageId?.let { contentId ->
+            onAction(
+                MessageAction.ModifyContent(
+                    contentId = contentId,
+                    content = message,
+                )
             )
-        } else {
-            messageItems = messageItems.map { item ->
-                if (item.id == activeMessageId) {
-                    item.copy(description = message)
-                } else {
-                    item
-                }
-            }
-        }
+        } ?: onAction(
+            MessageAction.CreateContent(
+                content = message,
+                files = emptyList(),
+            )
+        )
 
         closeMessageInput()
     }
@@ -169,16 +200,16 @@ fun MessageScreen(
 
     LaunchedEffect(pickedPhotoUris) {
         if (pickedPhotoUris.isNotEmpty()) {
-            val existingUris = photoItems.map { it.uri }.toSet()
-            val newUris = pickedPhotoUris
-                .distinct()
-                .filterNot { it in existingUris }
-            val nextPhotoId = (photoItems.maxOfOrNull { it.id } ?: 0L) + 1L
+            val files = pickedPhotoUris.mapIndexedNotNull { index, uri ->
+                uri.toFile(context, "photo-$index")
+            }
 
-            photoItems = photoItems + newUris.mapIndexed { index, uri ->
-                PhotoListItemUiModel(
-                    id = nextPhotoId + index,
-                    uri = uri,
+            if (files.isNotEmpty()) {
+                onAction(
+                    MessageAction.CreateContent(
+                        content = "",
+                        files = files,
+                    )
                 )
             }
         }
@@ -264,7 +295,7 @@ fun MessageScreen(
                                         if (isDeleteMode) {
                                             selectedIds = selectedIds.toggle(item.id)
                                         } else {
-                                            activeMessageId = item.id
+                                            activeMessageId = item.contentId
                                         }
                                     },
                                 )
@@ -321,7 +352,7 @@ fun MessageScreen(
                                 ) {
                                     GlideImage(
                                         modifier = Modifier.matchParentSize(),
-                                        imageModel = { item.uri },
+                                        imageModel = { item.imageModel },
                                     )
 
                                     if (isDeleteMode) {
@@ -379,20 +410,17 @@ fun MessageScreen(
                         .height(48.dp),
                     enabled = canDelete,
                     onClick = {
-                        when (currentTab) {
-                            MessageTab.MESSAGE -> {
-                                messageItems = messageItems.filterNot {
-                                    it.id in selectedIds
-                                }
-                            }
-
-                            MessageTab.PHOTO -> {
-                                photoItems = photoItems.filterNot {
-                                    it.id in selectedIds
-                                }
-                            }
+                        val contentIds = when (currentTab) {
+                            MessageTab.MESSAGE -> messageItems
+                                .filter { it.id in selectedIds }
+                                .map { it.contentId }
+                            MessageTab.PHOTO -> photoItems
+                                .filter { it.id in selectedIds }
+                                .map { it.contentId }
+                                .distinct()
                         }
 
+                        onAction(MessageAction.DeleteContent(contentIds))
                         selectedIds = emptySet()
                         isDeleteMode = false
                     },
@@ -613,17 +641,19 @@ private enum class MessageTab(
 }
 
 private data class MessageListItemUiModel(
-    val id: Long,
+    val id: String,
+    val contentId: Long,
     val title: String,
     val description: String,
 )
 
 private data class PhotoListItemUiModel(
-    val id: Long,
-    val uri: Uri,
+    val id: String,
+    val contentId: Long,
+    val imageModel: String,
 )
 
-private fun Set<Long>.toggle(id: Long): Set<Long> =
+private fun Set<String>.toggle(id: String): Set<String> =
     if (id in this) this - id else this + id
 
 @Preview
@@ -631,6 +661,7 @@ private fun Set<Long>.toggle(id: Long): Set<Long> =
 fun MessageScreenPreview() {
     MessageScreen(
         capsuleId = 0L,
+        data = MessageData(),
         onAction = {},
     )
 }

--- a/feature/message/src/main/java/com/idiotfrogs/message/MessageViewModel.kt
+++ b/feature/message/src/main/java/com/idiotfrogs/message/MessageViewModel.kt
@@ -1,30 +1,160 @@
 package com.idiotfrogs.message
 
+import androidx.compose.runtime.Immutable
+import com.idiotfrogs.domain.usecase.timecapsule.CreateTimeCapsuleContentUseCase
+import com.idiotfrogs.domain.usecase.timecapsule.DeleteTimeCapsuleContentUseCase
+import com.idiotfrogs.domain.usecase.timecapsule.GetMyTimeCapsuleContentUseCase
+import com.idiotfrogs.domain.usecase.timecapsule.ModifyTimeCapsuleContentUseCase
+import com.idiotfrogs.model.timecapsule.CapsuleContentsData
 import com.idiotfrogs.util.UiState
 import com.idiotfrogs.util.base.BaseViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.viewmodel.container
-import javax.inject.Inject
+import java.io.File
 
-@HiltViewModel
-class MessageViewModel @Inject constructor() :
-    BaseViewModel<UiState<Unit>, MessageSideEffect, MessageAction>() {
+@HiltViewModel(assistedFactory = MessageViewModel.Factory::class)
+class MessageViewModel @AssistedInject constructor(
+    @Assisted private val capsuleId: Long,
+    private val getMyTimeCapsuleContentUseCase: GetMyTimeCapsuleContentUseCase,
+    private val createTimeCapsuleContentUseCase: CreateTimeCapsuleContentUseCase,
+    private val modifyTimeCapsuleContentUseCase: ModifyTimeCapsuleContentUseCase,
+    private val deleteTimeCapsuleContentUseCase: DeleteTimeCapsuleContentUseCase,
+) : BaseViewModel<UiState<MessageData>, MessageSideEffect, MessageAction>() {
 
-    override val container: Container<UiState<Unit>, MessageSideEffect> =
-        container(UiState.Success(Unit))
+    override val container: Container<UiState<MessageData>, MessageSideEffect> = container(
+        initialState = UiState.Init,
+        onCreate = { fetchTimeCapsuleContent() }
+    )
+
+    private fun fetchTimeCapsuleContent() = safeLaunch {
+        getMyTimeCapsuleContentUseCase(capsuleId).onSuccess {
+            intent { reduce { UiState.Success(MessageData(contents = it)) } }
+        }.onFailure {
+            intent { reduce { UiState.Error(it.message) } }
+        }
+    }
+
+    private fun createTimeCapsuleContent(
+        content: String,
+        files: List<File>
+    ) {
+        safeLaunch {
+            createTimeCapsuleContentUseCase(
+                timeCapsuleId = capsuleId,
+                content = content,
+                files = files
+            ).onSuccess { response ->
+                intent {
+                    reduce {
+                        val currentData = (state as? UiState.Success)?.data ?: MessageData()
+                        UiState.Success(currentData.copy(contents = currentData.contents + response))
+                    }
+                }
+            }.onFailure {
+                intent { reduce { UiState.Error(it.message) } }
+            }
+        }
+    }
+
+    private fun modifyTimeCapsuleContent(
+        contentId: Long,
+        content: String
+    ) {
+        safeLaunch {
+            modifyTimeCapsuleContentUseCase(
+                contentId = contentId,
+                content = content
+            ).onSuccess { response ->
+                intent {
+                    reduce {
+                        val currentData = (state as? UiState.Success)?.data ?: MessageData()
+
+                        UiState.Success(
+                            currentData.copy(
+                                contents = currentData.contents.map { content ->
+                                    if (content.contentId == response.contentId) response else content
+                                }
+                            )
+                        )
+                    }
+                }
+            }.onFailure {
+                intent { reduce { UiState.Error(it.message) } }
+            }
+        }
+    }
+
+    private fun deleteTimeCapsuleContent(contentIds: List<Long>) {
+        safeLaunch {
+            deleteTimeCapsuleContentUseCase(contentIds).onSuccess {
+                intent {
+                    reduce {
+                        val currentData = (state as? UiState.Success)?.data ?: MessageData()
+
+                        UiState.Success(
+                            currentData.copy(
+                                contents = currentData.contents.filterNot { it.contentId in contentIds }
+                            )
+                        )
+                    }
+                }
+            }.onFailure {
+                intent { reduce { UiState.Error(it.message) } }
+            }
+        }
+    }
 
     override fun onAction(action: MessageAction) {
         when (action) {
             MessageAction.NavigateToBack -> intent {
                 postSideEffect(MessageSideEffect.NavigateToBack)
             }
+
+            is MessageAction.CreateContent -> createTimeCapsuleContent(
+                content = action.content,
+                files = action.files
+            )
+
+            is MessageAction.ModifyContent -> modifyTimeCapsuleContent(
+                contentId = action.contentId,
+                content = action.content
+            )
+
+            is MessageAction.DeleteContent -> deleteTimeCapsuleContent(action.contentIds)
         }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(capsuleId: Long): MessageViewModel
     }
 }
 
+@Immutable
+data class MessageData(
+    val contents: List<CapsuleContentsData> = emptyList(),
+)
+
 sealed interface MessageAction {
     data object NavigateToBack : MessageAction
+
+    data class CreateContent(
+        val content: String,
+        val files: List<File>,
+    ) : MessageAction
+
+    data class ModifyContent(
+        val contentId: Long,
+        val content: String,
+    ) : MessageAction
+
+    data class DeleteContent(
+        val contentIds: List<Long>,
+    ) : MessageAction
 }
 
 sealed interface MessageSideEffect {

--- a/feature/message/stability/message-debug.stability
+++ b/feature/message/stability/message-debug.stability
@@ -10,14 +10,14 @@ public fun com.idiotfrogs.message.MessageRoute(capsuleId: kotlin.Long, viewModel
   restartable: true
   params:
     - capsuleId: STABLE (primitive type)
-    - viewModel: RUNTIME (requires runtime check)
+    - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.idiotfrogs.message.MessageScreen(capsuleId: kotlin.Long, onAction: kotlin.Function1<com.idiotfrogs.message.MessageAction, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.idiotfrogs.message.MessageScreen(data: com.idiotfrogs.message.MessageData, onAction: kotlin.Function1<com.idiotfrogs.message.MessageAction, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - capsuleId: STABLE (primitive type)
+    - data: STABLE (marked @Stable or @Immutable)
     - onAction: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
 

--- a/feature/message/stability/message-release.stability
+++ b/feature/message/stability/message-release.stability
@@ -10,14 +10,14 @@ public fun com.idiotfrogs.message.MessageRoute(capsuleId: kotlin.Long, viewModel
   restartable: true
   params:
     - capsuleId: STABLE (primitive type)
-    - viewModel: RUNTIME (requires runtime check)
+    - viewModel: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
-public fun com.idiotfrogs.message.MessageScreen(capsuleId: kotlin.Long, onAction: kotlin.Function1<com.idiotfrogs.message.MessageAction, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.idiotfrogs.message.MessageScreen(data: com.idiotfrogs.message.MessageData, onAction: kotlin.Function1<com.idiotfrogs.message.MessageAction, kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
-    - capsuleId: STABLE (primitive type)
+    - data: STABLE (marked @Stable or @Immutable)
     - onAction: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
 


### PR DESCRIPTION
### 💡 개요
- #273 

### 📃 작업 내용
- 메시지 화면 API 연동
- 디테일 화면 UI에 빼먹은 부분 API 연동

### 💻 구현 화면
- 생성, 수정, 삭제 순서입니다.

Before | After
:--: | :--:
<img src="" width="300" /> | <video src="https://github.com/user-attachments/assets/504ea0fa-7d59-4500-a512-306df6060cb1" width="300" />
<img src="" width="300" /> | <video src="https://github.com/user-attachments/assets/c14e9946-89a1-4bc5-99bc-160ed223101b" width="300" />
<img src="" width="300" /> | <video src="https://github.com/user-attachments/assets/d2bea952-dae0-4e97-ba99-edf93b335c99" width="300" />

### 🎸 기타
- 삭제는 사진을 한번에 다중 업로드할 시 해당 사진들 중 하나만 삭제해도 전부 삭제되는 이슈가 있습니다. (다음 회의때 해당 부분 애기 이후 코드 반영 예정입니다.)