### PR TITLE
🔀 :: (#283) 예외 핸들링 구조 작업

### DIFF
--- a/core/network/src/main/java/com/idiotfrogs/network/util/ThrowableMapper.kt
+++ b/core/network/src/main/java/com/idiotfrogs/network/util/ThrowableMapper.kt
@@ -1,0 +1,29 @@
+package com.idiotfrogs.network.util
+
+import com.idiotfrogs.util.error.DomainError
+import com.idiotfrogs.util.exception.LoginRequiredException
+import retrofit2.HttpException
+import kotlin.coroutines.cancellation.CancellationException
+
+fun Throwable.toDomainError(): DomainError {
+    val exception = this as? HttpException ?: throw this
+    return when (exception.code()) {
+        400 -> DomainError.BadRequest(exception.message.orEmpty())
+        401 -> DomainError.Unauthorized(exception.message.orEmpty())
+        403 -> DomainError.Forbidden(exception.message.orEmpty())
+        404 -> DomainError.NotFound(exception.message.orEmpty())
+        409 -> DomainError.Conflict(exception.message.orEmpty())
+        500 -> DomainError.Server(exception.message.orEmpty())
+        else -> throw exception
+    }
+}
+
+inline fun <T> mapToDomainError(block: () -> T): T = try {
+    block()
+} catch (e: CancellationException) {
+    throw e
+} catch (e: LoginRequiredException) {
+    throw e
+} catch (e: Exception) {
+    throw e.toDomainError()
+}

--- a/core/util/src/main/java/com/idiotfrogs/util/error/DomainError.kt
+++ b/core/util/src/main/java/com/idiotfrogs/util/error/DomainError.kt
@@ -1,0 +1,10 @@
+package com.idiotfrogs.util.error
+
+sealed class DomainError(message: String) : Exception(message) {
+    data class BadRequest(override val message: String): DomainError(message)
+    data class Unauthorized(override val message: String): DomainError(message)
+    data class Forbidden(override val message: String): DomainError(message)
+    data class NotFound(override val message: String): DomainError(message)
+    data class Conflict(override val message: String): DomainError(message)
+    data class Server(override val message: String): DomainError(message)
+}

--- a/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepositoryImpl.kt
+++ b/data/src/main/java/com/idiotfrogs/data/repository/timecapsule/TimeCapsuleRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateRequest
 import com.idiotfrogs.model.timecapsule.TimeCapsuleCreateResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleInviteCodeResponse
 import com.idiotfrogs.model.timecapsule.TimeCapsuleResponse
+import com.idiotfrogs.network.util.mapToDomainError
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
@@ -29,22 +30,24 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
     ): TimeCapsuleCreateResponse {
         val imageRequestBody = mainImage.asRequestBody("image/jpeg".toMediaType())
         val imagePart = MultipartBody.Part.createFormData("mainImage", mainImage.name, imageRequestBody)
-        return timeCapsuleDataSource.createTimeCapsule(
-            timeCapsuleCreateDto,
-            imagePart
-        )
+        return mapToDomainError {
+            timeCapsuleDataSource.createTimeCapsule(
+                timeCapsuleCreateDto,
+                imagePart
+            )
+        }
     }
 
     override suspend fun getMyTimeCapsule(): List<MyTimeCapsuleResponse> {
-        return timeCapsuleDataSource.getMyTimeCapsule()
+        return mapToDomainError { timeCapsuleDataSource.getMyTimeCapsule() }
     }
 
     override suspend fun deleteTimeCapsule(capsuleId: Long) {
-        return timeCapsuleDataSource.deleteTimeCapsule(capsuleId)
+        return mapToDomainError { timeCapsuleDataSource.deleteTimeCapsule(capsuleId) }
     }
 
     override suspend fun getTimeCapsule(capsuleId: Long): TimeCapsuleResponse {
-        return timeCapsuleDataSource.getTimeCapsule(capsuleId)
+        return mapToDomainError { timeCapsuleDataSource.getTimeCapsule(capsuleId) }
     }
 
     override suspend fun getTimesCapsuleCollaborators(
@@ -52,40 +55,40 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
         page: Int,
         size: Int,
     ): TimeCapsuleCollaboratorsResponse {
-        return timeCapsuleDataSource.getTimesCapsuleCollaborators(capsuleId, page, size)
+        return mapToDomainError { timeCapsuleDataSource.getTimesCapsuleCollaborators(capsuleId, page, size) }
     }
 
     override suspend fun getTimeCapsuleInviteCode(capsuleId: Long): TimeCapsuleInviteCodeResponse {
-        return timeCapsuleDataSource.getTimeCapsuleInviteCode(capsuleId)
+        return mapToDomainError { timeCapsuleDataSource.getTimeCapsuleInviteCode(capsuleId) }
     }
 
     override suspend fun requestCollaborator(body: PendingCollaboratorsRequest) {
-        return timeCapsuleDataSource.requestCollaborator(body)
+        return mapToDomainError { timeCapsuleDataSource.requestCollaborator(body) }
     }
 
     override suspend fun processRequest(requestId: Long, body: ProcessCollaboratorRequest) {
-        return timeCapsuleDataSource.processRequest(requestId, body)
+        return mapToDomainError { timeCapsuleDataSource.processRequest(requestId, body) }
     }
 
     override suspend fun buryTimeCapsule(
         capsuleId: Long,
         body: BuryTimeCapsuleRequest
     ): TimeCapsuleResponse {
-        return timeCapsuleDataSource.buryTimeCapsule(capsuleId, body)
+        return mapToDomainError { timeCapsuleDataSource.buryTimeCapsule(capsuleId, body) }
     }
 
     override suspend fun delegationTimeCapsuleHost(
         capsuleId: Long,
         targetUserId: Long
     ) {
-        return timeCapsuleDataSource.delegationTimeCapsuleHost(capsuleId, targetUserId)
+        return mapToDomainError { timeCapsuleDataSource.delegationTimeCapsuleHost(capsuleId, targetUserId) }
     }
 
     override suspend fun deleteTimesCapsuleContributors(
         capsuleId: Long,
         targetUserId: Long
     ) {
-        return timeCapsuleDataSource.deleteTimesCapsuleContributors(capsuleId, targetUserId)
+        return mapToDomainError { timeCapsuleDataSource.deleteTimesCapsuleContributors(capsuleId, targetUserId) }
     }
 
     override suspend fun searchTimesCapsuleCollaborators(
@@ -94,16 +97,18 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
         page: Int,
         size: Int
     ): TimeCapsuleCollaboratorsResponse {
-        return timeCapsuleDataSource.searchTimesCapsuleCollaborators(
-            capsuleId = capsuleId,
-            nickname = nickname,
-            page = page,
-            size = size
-        )
+        return mapToDomainError {
+            timeCapsuleDataSource.searchTimesCapsuleCollaborators(
+                capsuleId = capsuleId,
+                nickname = nickname,
+                page = page,
+                size = size
+            )
+        }
     }
 
     override suspend fun leaveTimeCapsule(capsuleId: Long) {
-        return timeCapsuleDataSource.leaveTimeCapsule(capsuleId)
+        return mapToDomainError { timeCapsuleDataSource.leaveTimeCapsule(capsuleId) }
     }
 
     override suspend fun getTimeCapsuleContent(
@@ -111,11 +116,13 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
         page: Int,
         size: Int,
     ): TimeCapsuleContentResponse {
-        return timeCapsuleDataSource.getTimeCapsuleContent(
-            timeCapsuleId = timeCapsuleId,
-            page = page,
-            size = size
-        )
+        return mapToDomainError {
+            timeCapsuleDataSource.getTimeCapsuleContent(
+                timeCapsuleId = timeCapsuleId,
+                page = page,
+                size = size
+            )
+        }
     }
 
     override suspend fun getMyTimeCapsuleContent(timeCapsuleId: Long): List<MyCapsuleContentsData> {
@@ -133,30 +140,36 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
             MultipartBody.Part.createFormData("files", it.name, requestBody)
         }
 
-        return timeCapsuleDataSource.createTimeCapsuleContent(
-            timeCapsuleId = timeCapsuleId,
-            content = contentBody,
-            files = fileParts
-        )
+        return mapToDomainError {
+            timeCapsuleDataSource.createTimeCapsuleContent(
+                timeCapsuleId = timeCapsuleId,
+                content = contentBody,
+                files = fileParts
+            )
+        }
     }
 
     override suspend fun modifyTimeCapsuleContent(
         contentId: Long,
         content: String
     ): CapsuleContentsData {
-        return timeCapsuleDataSource.modifyTimeCapsuleContent(
-            contentId = contentId,
-            content = content
-        )
+        return mapToDomainError {
+            timeCapsuleDataSource.modifyTimeCapsuleContent(
+                contentId = contentId,
+                content = content
+            )
+        }
     }
 
     override suspend fun deleteTimeCapsuleContent(
         contentIds: List<Long>,
         fileIds: List<Long>,
     ) {
-        return timeCapsuleDataSource.deleteTimeCapsuleContent(
-            contentIds = contentIds,
-            fileIds = fileIds
-        )
+        return mapToDomainError {
+            timeCapsuleDataSource.deleteTimeCapsuleContent(
+                contentIds = contentIds,
+                fileIds = fileIds
+            )
+        }
     }
 }

--- a/data/src/main/java/com/idiotfrogs/data/repository/user/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/idiotfrogs/data/repository/user/UserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.idiotfrogs.data.repository.user
 import com.idiotfrogs.data.datasource.user.UserDataSource
 import com.idiotfrogs.model.user.ProfileResponse
 import com.idiotfrogs.model.user.UserResponse
+import com.idiotfrogs.network.util.mapToDomainError
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
@@ -14,11 +15,11 @@ class UserRepositoryImpl @Inject constructor(
     private val userDataSource: UserDataSource
 ) : UserRepository {
     override suspend fun getMyProfile(): ProfileResponse {
-        return userDataSource.getMyProfile()
+        return mapToDomainError { userDataSource.getMyProfile() }
     }
 
     override suspend fun withdraw() {
-        userDataSource.withdraw()
+        mapToDomainError { userDataSource.withdraw() }
     }
 
     override suspend fun updateMyProfile(
@@ -34,11 +35,13 @@ class UserRepositoryImpl @Inject constructor(
             imageRequestBody
         )
 
-        return userDataSource.updateMyProfile(
-            userId = userId,
-            profileImage = imagePart,
-            nickname = nickname
-        )
+        return mapToDomainError {
+            userDataSource.updateMyProfile(
+                userId = userId,
+                profileImage = imagePart,
+                nickname = nickname
+            )
+        }
     }
 
     override suspend fun signUp(
@@ -47,9 +50,11 @@ class UserRepositoryImpl @Inject constructor(
     ): UserResponse {
         val imageRequestBody = profileImage.asRequestBody("image/jpeg".toMediaType())
         val imagePart = MultipartBody.Part.createFormData("profileImage", profileImage.name, imageRequestBody)
-        return userDataSource.signUp(
-            nickname = nickname,
-            profileImage = imagePart
-        )
+        return mapToDomainError {
+            userDataSource.signUp(
+                nickname = nickname,
+                profileImage = imagePart
+            )
+        }
     }
 }


### PR DESCRIPTION
### 💡 개요
- #283

### 📃 작업 내용
- Domain은 network error나 error code를 알지 못해야 함 -> 도메인 에러 정의 및 매핑
- 매핑은 repository 구현체 단에서 이루어져야 하므로 매핑 함수 추가

### 💻 구현 화면
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

### 🎸 기타
- 작업하다보니 기존 safeCatching를 유지해야 할지, 아니면 구조를 바꿔야 할지, 삭제해야 할지 의논이 많이 필요한 부분이라 선작업분만 작업하였습니다.