### PR TITLE
🔀 :: (#289) 자잘한 UI 수정

### DIFF
--- a/common/extension/src/main/java/com/idiotfrogs/extension/LocalDateTimeExtension.kt
+++ b/common/extension/src/main/java/com/idiotfrogs/extension/LocalDateTimeExtension.kt
@@ -16,7 +16,7 @@ fun LocalDateTime?.toYearMonthDayWeek(): String =
 
 @OptIn(ExperimentalTime::class)
 fun LocalDateTime?.toDday(): String {
-    val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+    val today = Clock.System.todayIn(TimeZone.of("Asia/Seoul"))
     val targetDate = this?.date
     val diff = targetDate?.toEpochDays()?.minus(today.toEpochDays())
 
@@ -27,7 +27,7 @@ fun LocalDateTime?.toDday(): String {
 fun LocalDateTime?.toOpenRemainingText(): String {
     if (this == null) return "묻기 전"
 
-    val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+    val today = Clock.System.todayIn(TimeZone.of("Asia/Seoul"))
     val diff = date.toEpochDays() - today.toEpochDays()
 
     return when {

--- a/core/designsystem/src/main/java/com/idiotfrogs/designsystem/component/MSCalender.kt
+++ b/core/designsystem/src/main/java/com/idiotfrogs/designsystem/component/MSCalender.kt
@@ -56,7 +56,7 @@ fun MSCalender(
     showSealDate: Boolean = false,
     onDateSelected: (LocalDateTime) -> Unit
 ) {
-    val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+    val today = Clock.System.todayIn(TimeZone.of("Asia/Seoul"))
     val initialSelectedDate = if (showSealDate) {
         today.plus(1, DateTimeUnit.DAY)
     } else {

--- a/core/designsystem/src/main/java/com/idiotfrogs/designsystem/component/MSDialog.kt
+++ b/core/designsystem/src/main/java/com/idiotfrogs/designsystem/component/MSDialog.kt
@@ -223,6 +223,75 @@ fun MSTitleDialog(
     }
 }
 
+@Composable
+fun MSHeaderDialog(
+    header: @Composable ColumnScope.() -> Unit,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+    confirmText: String = "확인",
+    cancelText: String = "취소",
+    confirmButtonColor: Color = MSTheme.color.primaryNormal,
+    cancelButtonColor: Color = MSTheme.color.greyG1,
+    confirmTextColor: Color = MSTheme.color.white,
+    cancelTextColor: Color = MSTheme.color.greyG4,
+    content: @Composable ColumnScope.() -> Unit = { Spacer(Modifier.height(24.dp)) },
+) {
+    Dialog(onDismissRequest = onCancel) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .wavyStroke(
+                    color = MSTheme.color.white,
+                    fillColor = MSTheme.color.white,
+                    contentPadding = 20.dp,
+                )
+        ) {
+            header()
+            content()
+            Row(modifier = Modifier.fillMaxWidth()) {
+                MSButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onCancel,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = cancelButtonColor
+                    ),
+                    pressColors = ButtonDefaults.buttonColors(
+                        containerColor = cancelButtonColor
+                    ),
+                    wavyStrokeColor = cancelButtonColor,
+                    contentPadding = PaddingValues(12.dp)
+                ) {
+                    MSText(
+                        text = cancelText,
+                        fontSize = 16.dp,
+                        color = cancelTextColor
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                MSButton(
+                    modifier = Modifier.weight(1f),
+                    onClick = onConfirm,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = confirmButtonColor
+                    ),
+                    pressColors = ButtonDefaults.buttonColors(
+                        containerColor = confirmButtonColor
+                    ),
+                    wavyStrokeColor = confirmButtonColor,
+                    contentPadding = PaddingValues(11.dp)
+                ) {
+                    MSText(
+                        text = confirmText,
+                        fontSize = 16.dp,
+                        color = confirmTextColor
+                    )
+                }
+            }
+        }
+    }
+}
+
 @Preview
 @Composable
 fun MSDialogPreview() {

--- a/core/designsystem/stability/designsystem-debug.stability
+++ b/core/designsystem/stability/designsystem-debug.stability
@@ -128,6 +128,23 @@ public fun com.idiotfrogs.designsystem.component.MSGalleryLayout(images: kotlin.
     - isSeal: STABLE (primitive type)
 
 @Composable
+public fun com.idiotfrogs.designsystem.component.MSHeaderDialog(header: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.ColumnScope, kotlin.Unit>, onConfirm: kotlin.Function0<kotlin.Unit>, onCancel: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, confirmText: kotlin.String, cancelText: kotlin.String, confirmButtonColor: androidx.compose.ui.graphics.Color, cancelButtonColor: androidx.compose.ui.graphics.Color, confirmTextColor: androidx.compose.ui.graphics.Color, cancelTextColor: androidx.compose.ui.graphics.Color, content: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.ColumnScope, kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - header: STABLE (composable function type)
+    - onConfirm: STABLE (function type)
+    - onCancel: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - confirmText: STABLE (String is immutable)
+    - cancelText: STABLE (String is immutable)
+    - confirmButtonColor: STABLE (marked @Stable or @Immutable)
+    - cancelButtonColor: STABLE (marked @Stable or @Immutable)
+    - confirmTextColor: STABLE (marked @Stable or @Immutable)
+    - cancelTextColor: STABLE (marked @Stable or @Immutable)
+    - content: STABLE (composable function type)
+
+@Composable
 public fun com.idiotfrogs.designsystem.component.MSLoadingIndicator(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true

--- a/core/designsystem/stability/designsystem-release.stability
+++ b/core/designsystem/stability/designsystem-release.stability
@@ -128,6 +128,23 @@ public fun com.idiotfrogs.designsystem.component.MSGalleryLayout(images: kotlin.
     - isSeal: STABLE (primitive type)
 
 @Composable
+public fun com.idiotfrogs.designsystem.component.MSHeaderDialog(header: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.ColumnScope, kotlin.Unit>, onConfirm: kotlin.Function0<kotlin.Unit>, onCancel: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier, confirmText: kotlin.String, cancelText: kotlin.String, confirmButtonColor: androidx.compose.ui.graphics.Color, cancelButtonColor: androidx.compose.ui.graphics.Color, confirmTextColor: androidx.compose.ui.graphics.Color, cancelTextColor: androidx.compose.ui.graphics.Color, content: @[Composable] @[ExtensionFunctionType] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.ColumnScope, kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - header: STABLE (composable function type)
+    - onConfirm: STABLE (function type)
+    - onCancel: STABLE (function type)
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - confirmText: STABLE (String is immutable)
+    - cancelText: STABLE (String is immutable)
+    - confirmButtonColor: STABLE (marked @Stable or @Immutable)
+    - cancelButtonColor: STABLE (marked @Stable or @Immutable)
+    - confirmTextColor: STABLE (marked @Stable or @Immutable)
+    - cancelTextColor: STABLE (marked @Stable or @Immutable)
+    - content: STABLE (composable function type)
+
+@Composable
 public fun com.idiotfrogs.designsystem.component.MSLoadingIndicator(modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true

--- a/feature/create/src/main/java/com/idiotfrogs/create/CreateScreen.kt
+++ b/feature/create/src/main/java/com/idiotfrogs/create/CreateScreen.kt
@@ -3,9 +3,11 @@ package com.idiotfrogs.create
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -85,7 +87,9 @@ private fun CreateScreen(
     val (imageUri, launchImagePicker) = rememberPickerState()
     val isShowKeyboard = rememberKeyboardVisibility()
 
-    val enabled = titleTextFieldState.text.isNotEmpty() && imageUri != null
+    val titleText = titleTextFieldState.text.toString()
+    val isTitleTooLong = titleText.length > 20
+    val enabled = titleText.isNotEmpty() && !isTitleTooLong && imageUri != null
 
     val buttonHorizontalPadding by animateDpAsState(if (isShowKeyboard) 0.dp else 20.dp)
 
@@ -162,6 +166,25 @@ private fun CreateScreen(
                     textFieldState = titleTextFieldState,
                     hint = "제목을 입력해주세요.",
                 )
+                if (isTitleTooLong) {
+                    Spacer(Modifier.height(9.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Image(
+                            painter = painterResource(R.drawable.ic_warning),
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        MSText(
+                            text = "최소 1글자에서 20글자까지 입력할 수 있습니다.",
+                            fontSize = 12.dp,
+                            fontWeight = FontWeight.Normal,
+                            color = MSTheme.color.red,
+                        )
+                    }
+                }
                 Spacer(Modifier.height(16.dp))
                 MSText(
                     modifier = Modifier.padding(start = 6.dp),

--- a/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
@@ -47,8 +47,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.idiotfrogs.designsystem.component.MSAnnotatedText
 import com.idiotfrogs.designsystem.component.MSCalender
 import com.idiotfrogs.designsystem.component.MSDashHorizontalDivider
+import com.idiotfrogs.designsystem.component.MSHeaderDialog
 import com.idiotfrogs.designsystem.component.MSLoadingOverlay
-import com.idiotfrogs.designsystem.component.MSTitleDialog
 import com.idiotfrogs.designsystem.component.MSText
 import com.idiotfrogs.designsystem.component.MSToast
 import com.idiotfrogs.designsystem.component.button.MSButton
@@ -149,8 +149,21 @@ fun DetailScreen(
     var selectedOpenAt by remember { mutableStateOf(defaultOpenAt) }
 
     if (showBuryDialog) {
-        MSTitleDialog(
-            title = "티켓 오픈일 설정",
+        MSHeaderDialog(
+            header = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    MSText(
+                        text = "티켓 오픈일 설정  ·  ",
+                        fontSize = 20.dp,
+                    )
+                    MSText(
+                        text = "00시 오픈",
+                        fontSize = 16.dp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MSTheme.color.primaryDark,
+                    )
+                }
+            },
             confirmText = "묻기",
             cancelText = "취소",
             onConfirm = {

--- a/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/idiotfrogs/detail/DetailScreen.kt
@@ -142,7 +142,7 @@ fun DetailScreen(
 
     val defaultOpenAt = remember {
         Clock.System
-            .todayIn(TimeZone.currentSystemDefault())
+            .todayIn(TimeZone.of("Asia/Seoul"))
             .plus(1, DateTimeUnit.DAY)
             .atTime(0, 0, 0, 0)
     }


### PR DESCRIPTION
### 💡 개요
- #289 

### 📃 작업 내용
- 생성 화면 title 입력 최대 길이 관련 에러 UI 추가
- 달력 (시간) 관련 로직 UTC -> KST 변경
- 묻기 다이얼로그 UI 변경

### 💻 구현 화면
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/user-attachments/assets/0bba4a11-1250-4e12-9c8e-8aebb09a3a02" width="300" />
<img src="" width="300" /> | <img src="https://github.com/user-attachments/assets/fc6927b6-89b5-46ae-9de6-479e543577ac" width="300" />

### 🎸 기타
- 생성 화면 에러 로직에서 추가 변동 사항이 있습니다.